### PR TITLE
Replace Ollama with pluggable LLM factory + Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# LLM Provider — choose one: anthropic, openai, ollama
+LLM_PROVIDER=anthropic
+LLM_MODEL=claude-haiku-4-5-20251001
+
+# Required for LLM_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# Required for LLM_PROVIDER=openai (e.g. Apertus)
+# LLM_BASE_URL=https://api.apertus.ch/v1
+# LLM_API_KEY=your-key-here
+
+# Optional — SRG news API (pending approval)
+SRGSSR_CLIENT_ID=
+SRGSSR_CLIENT_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python3", "api_server.py"]

--- a/api_server.py
+++ b/api_server.py
@@ -130,7 +130,15 @@ async def chat_completions(request: ChatRequest):
         result = await graph.ainvoke({"messages": langchain_messages})
 
         final_message = result["messages"][-1]
-        response_content = final_message.content if hasattr(final_message, "content") else str(final_message)
+        raw_content = final_message.content if hasattr(final_message, "content") else str(final_message)
+        # Claude returns content as a list of blocks when tools are bound — extract text
+        if isinstance(raw_content, list):
+            response_content = "".join(
+                block.get("text", "") if isinstance(block, dict) else str(block)
+                for block in raw_content
+            )
+        else:
+            response_content = raw_content
 
         return ChatResponse(
             id=chat_id,

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -7,12 +7,12 @@ import logging
 from typing import Annotated, Literal
 from typing_extensions import TypedDict
 
-from langchain_ollama import ChatOllama
 from langchain_core.messages import HumanMessage, SystemMessage, AIMessage, ToolMessage
 from langgraph.graph import StateGraph, END
 from langgraph.graph.message import add_messages
 from langgraph.types import StreamWriter
 
+from backend.config.settings import get_llm
 from backend.tools.tools import TOOL_DEFINITIONS, dispatch_tool
 
 logger = logging.getLogger("zuribot.agent")
@@ -62,16 +62,18 @@ def call_model(state: AgentState, writer: StreamWriter) -> AgentState:
     """Call the LLM with current messages, streaming text tokens via writer."""
     messages = state["messages"]
 
-    llm = ChatOllama(
-        model="qwen2.5:7b",
-        temperature=0.1,
-    ).bind_tools(list(TOOL_DEFINITIONS))
+    llm = get_llm().bind_tools(list(TOOL_DEFINITIONS))
 
     accumulated = None
     for chunk in llm.stream(messages):
         # Emit text tokens only — skip tool_call_chunks (they carry JSON args, not text)
         if chunk.content and not chunk.tool_call_chunks:
-            writer({"token": chunk.content})
+            # Claude can return content as a list of blocks
+            text = chunk.content
+            if isinstance(text, list):
+                text = "".join(b.get("text", "") if isinstance(b, dict) else str(b) for b in text)
+            if text:
+                writer({"token": text})
         accumulated = chunk if accumulated is None else accumulated + chunk
 
     if accumulated is None:

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,0 +1,48 @@
+"""
+LLM provider configuration.
+Controlled via environment variables so swapping providers requires no code changes.
+
+Supported providers:
+  anthropic  — Claude API (default, recommended)
+  openai     — Any OpenAI-compatible API (includes Apertus)
+  ollama     — Local Ollama (for offline dev)
+"""
+
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Find .env by walking up from this file's location
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env", override=True)
+
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "anthropic")
+LLM_MODEL = os.getenv("LLM_MODEL", "claude-haiku-4-5-20251001")
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "")  # only needed for openai-compatible providers
+LLM_API_KEY = os.getenv("LLM_API_KEY", "")    # only needed for openai-compatible providers
+
+
+def get_llm():
+    """Return a LangChain chat model based on environment config."""
+    if LLM_PROVIDER == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(
+            model=LLM_MODEL,
+            temperature=0.1,
+            api_key=os.getenv("ANTHROPIC_API_KEY"),
+        )
+
+    elif LLM_PROVIDER == "openai":
+        # Works for any OpenAI-compatible API — including Apertus.
+        # Set LLM_BASE_URL and LLM_API_KEY in .env to point at the provider.
+        from langchain_openai import ChatOpenAI
+        kwargs = dict(model=LLM_MODEL, temperature=0.1, api_key=LLM_API_KEY)
+        if LLM_BASE_URL:
+            kwargs["base_url"] = LLM_BASE_URL
+        return ChatOpenAI(**kwargs)
+
+    elif LLM_PROVIDER == "ollama":
+        from langchain_ollama import ChatOllama
+        return ChatOllama(model=LLM_MODEL, temperature=0.1)
+
+    else:
+        raise ValueError(f"Unknown LLM_PROVIDER: {LLM_PROVIDER!r}. Use 'anthropic', 'openai', or 'ollama'.")

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+
+  zuribot:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - ../.env
+    restart: unless-stopped
+    networks:
+      - zuribot-net
+
+  searxng:
+    image: searxng/searxng:latest
+    ports:
+      - "8888:8080"
+    environment:
+      - SEARXNG_BASE_URL=http://localhost:8888
+      - SEARXNG_SECRET=zuribot-searxng-secret
+    restart: unless-stopped
+    networks:
+      - zuribot-net
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    ports:
+      - "3000:8080"
+    environment:
+      - OPENAI_API_BASE_URL=http://zuribot:8000/v1
+      - OPENAI_API_KEY=zuribot
+    volumes:
+      - open-webui-data:/app/backend/data
+    depends_on:
+      - zuribot
+    restart: unless-stopped
+    networks:
+      - zuribot-net
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - zuribot
+      - open-webui
+    restart: unless-stopped
+    networks:
+      - zuribot-net
+
+volumes:
+  open-webui-data:
+
+networks:
+  zuribot-net:
+    driver: bridge

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,31 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        # Open WebUI (main chat interface)
+        location / {
+            proxy_pass http://open-webui:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            # Required for SSE streaming
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+        }
+
+        # ZüriBot API (direct access if needed)
+        location /zuribot/ {
+            rewrite ^/zuribot(/.*)$ $1 break;
+            proxy_pass http://zuribot:8000;
+            proxy_set_header Host $host;
+
+            # Required for SSE streaming
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 langchain-ollama>=0.3.0
+langchain-anthropic>=0.3.0
+langchain-openai>=0.3.0
 langchain-core>=0.3.0
 langgraph>=0.2.0
+python-dotenv>=1.0.0
 mcp>=1.0.0
 pydantic>=2.0.0
 fastapi>=0.110.0


### PR DESCRIPTION
## Changes

### LLM abstraction layer
- **`backend/config/settings.py`** — new `get_llm()` factory reads `LLM_PROVIDER` from `.env`. Supports:
  - `anthropic` — Claude API (current, default)
  - `openai` — any OpenAI-compatible API including **Apertus** (set `LLM_BASE_URL` + `LLM_API_KEY`)
  - `ollama` — local Ollama (offline dev)
- **`backend/agent.py`** — replace hardcoded `ChatOllama` with `get_llm()`
- **`api_server.py`** — handle Claude's list-format content blocks correctly

Swapping to Apertus later = change 2 lines in `.env`, zero code changes.

### Docker Compose
- **`Dockerfile`** — containerises the FastAPI server
- **`deploy/docker-compose.yml`** — one-command startup: zuribot, searxng, open-webui, nginx (no Ollama needed)
- **`deploy/nginx.conf`** — reverse proxy with SSE streaming support (`proxy_buffering off`)
- **`.env.example`** — documents all required environment variables

### Usage
```bash
# Development (as before)
source venv/bin/activate && python3 api_server.py

# Production (new)
cd deploy && docker compose up -d
```

## Tested
- Claude API connection verified ✓
- Full agent round-trip with weather tool call ✓
- Clean formatted response in German ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)