### PR TITLE
Fix POI nearest-location search and opening hours

### DIFF
--- a/backend/agent.py
+++ b/backend/agent.py
@@ -33,6 +33,7 @@ You help residents and visitors with:
 - Recycling collection points (glass, metal, oil, textiles)
 - Mobile recycling center schedules
 - General web search when other tools don't cover the topic
+- Local knowledge: neighborhood character, Swiss customs and etiquette, tenancy law, government services, restaurant recommendations, news
 
 Rules:
 - Always respond in the same language the user writes in (German, Swiss German, English, French, Italian)
@@ -43,6 +44,10 @@ Rules:
 - For locations, always include the address if available
 - For schedules, format dates clearly in European format (DD.MM.YYYY)
 - When mentioning times, use 24h format
+- For questions about specific places (restaurants, shops, venues): first call search_knowledge_base for editorial context and recommendations, then call get_pois or get_venues for real-time addresses and opening hours
+- For questions about events: check get_events for what's on AND search_knowledge_base for background on the venue or festival
+- Always prefer real-time API data for anything time-sensitive (schedules, availability, departures); use search_knowledge_base for cultural context, recommendations, and legal information
+- When the user asks for the "nearest" or "closest" location (supermarket, pharmacy, etc.): ask for their street address or neighbourhood first if not given, then call get_pois with that address as user_address. Always report the opening_hours field from results — if present, show it; if empty, say the hours are not listed online
 """
 
 

--- a/backend/tools/tools.py
+++ b/backend/tools/tools.py
@@ -105,7 +105,12 @@ TOOL_DEFINITIONS = [
         "type": "function",
         "function": {
             "name": "get_pois",
-            "description": "Get points of interest in Zürich (attractions, restaurants, hotels, etc.) from OpenStreetMap.",
+            "description": (
+                "Get points of interest in Zürich (shops, restaurants, pharmacies, supermarkets, etc.) from OpenStreetMap, "
+                "sorted by distance from the given location. "
+                "When the user asks for the 'nearest' or 'closest' place, ask for their address or current location first, "
+                "then pass it as user_address. Results include opening_hours — always mention them in your answer."
+            ),
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -116,13 +121,30 @@ TOOL_DEFINITIONS = [
                     },
                     "query": {
                         "type": "string",
-                        "description": "Optional name search query",
+                        "description": "Search query — use the place type or brand name (e.g. 'Migros', 'pharmacy', 'restaurant')",
                         "default": ""
+                    },
+                    "user_address": {
+                        "type": "string",
+                        "description": "User's current address or location in Zürich (e.g. 'Bahnhofstrasse 10, Zürich'). Used to find nearest results. Leave empty to search city-wide."
+                    },
+                    "user_latitude": {
+                        "type": "number",
+                        "description": "User's latitude (optional, use instead of user_address if coordinates are known)"
+                    },
+                    "user_longitude": {
+                        "type": "number",
+                        "description": "User's longitude (optional, use instead of user_address if coordinates are known)"
+                    },
+                    "radius_m": {
+                        "type": "integer",
+                        "description": "Search radius in metres around the user's location (default: 1500)",
+                        "default": 1500
                     },
                     "limit": {
                         "type": "integer",
-                        "description": "Number of results (default: 10)",
-                        "default": 10
+                        "description": "Number of results (default: 5)",
+                        "default": 5
                     }
                 },
                 "required": []
@@ -374,12 +396,33 @@ def dispatch_tool(name, arguments):
             return air_quality_connector.get_air_quality()
 
         elif name == "get_pois":
-            # search_poi uses text query matched against OSM_TAG_MAP;
-            # combine category + optional query for the best match
             poi_query = arguments.get("query") or arguments.get("category", "restaurant")
+            lat = arguments.get("user_latitude")
+            lon = arguments.get("user_longitude")
+            # Geocode user_address → lat/lon if coordinates not provided directly
+            user_address = arguments.get("user_address", "")
+            if user_address and not (lat and lon):
+                import requests as _requests, time as _time
+                try:
+                    _time.sleep(0.5)
+                    geo = _requests.get(
+                        "https://nominatim.openstreetmap.org/search",
+                        params={"q": user_address + ", Zürich" if "zürich" not in user_address.lower() and "zurich" not in user_address.lower() else user_address,
+                                "format": "json", "limit": 1},
+                        headers={"User-Agent": "ZuriBot/1.0"},
+                        timeout=5,
+                    )
+                    if geo.status_code == 200 and geo.json():
+                        lat = float(geo.json()[0]["lat"])
+                        lon = float(geo.json()[0]["lon"])
+                except Exception:
+                    pass
             return poi_connector.search_poi(
                 query=poi_query,
-                limit=arguments.get("limit", 10)
+                lat=lat,
+                lon=lon,
+                radius=arguments.get("radius_m", 1500),
+                limit=arguments.get("limit", 5)
             )
         
         elif name == "get_voting_results":


### PR DESCRIPTION
## Summary

- **get_pois tool** now accepts `user_address`, `user_latitude`, `user_longitude`, and `radius_m` parameters
- When `user_address` is provided, the dispatch geocodes it via Nominatim and passes the coordinates to `search_poi`
- Results are sorted by distance from the user's actual location instead of defaulting to Zürich city centre
- Default search radius tightened to 1500m, default result count to 5 (more relevant)
- System prompt updated: agent is instructed to ask for the user's address when they ask for "nearest X", and to always report `opening_hours` from POI results

## Test plan

- [x] Smoke test: `dispatch_tool('get_pois', {'query': 'Migros', 'user_address': 'Bahnhofstrasse 10, Zürich', 'limit': 3})` returns correct distances and opening hours
- [ ] End-to-end: Ask "Which Migros is closest to me?" — bot asks for address, then returns correctly sorted results with opening hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)