### PR TITLE
kb: scaffold Phase 1 pipeline (chunker, metadata, writer, tokenizer)

### DIFF
--- a/backend/kb/__init__.py
+++ b/backend/kb/__init__.py
@@ -1,0 +1,12 @@
+"""Knowledge base Phase 1 pipeline — crawl, chunk, emit .jsonl.
+
+Spec: docs/knowledge_base.md.
+
+No embedding, no vector DB writes here. Phase 2 (AI pod) consumes the
+.jsonl output, embeds with EmbeddingGemma-300M, upserts into Qdrant.
+"""
+
+from backend.kb.metadata import Chunk, make_chunk_id, make_doc_id
+from backend.kb.tokenizer import count_tokens
+
+__all__ = ["Chunk", "make_chunk_id", "make_doc_id", "count_tokens"]

--- a/backend/kb/chunker.py
+++ b/backend/kb/chunker.py
@@ -1,0 +1,375 @@
+"""Structural chunker — spec §5 and §6.
+
+Public API: ``chunk_document(doc)`` returning ``list[Chunk]``.
+
+Strategy (spec §5.1):
+    1. Structural split on H1/H2/H3 + paragraph boundaries.
+    2. Recursive character fallback if structure is weak.
+    3. Fixed token windows as last resort.
+
+Size targets (§5.2): 400-600 tokens, overlap 10-15%, hard max 1000,
+hard min 100. Never split mid-sentence.
+
+Per-doc_type dispatch (§5.3):
+    article     -> structural + 400-600 tokens
+    procedure   -> whole if <=800 tokens else split on steps
+    reference   -> one chunk, no splitting
+    statute     -> one article = one chunk, split on Absatz if >2000
+    historical  -> structural + 300-400 tokens
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Optional
+
+from backend.kb.metadata import (
+    Authority,
+    Category,
+    Chunk,
+    DocType,
+    make_chunk_id,
+    make_doc_id,
+)
+from backend.kb.tokenizer import count_tokens
+
+logger = logging.getLogger("zuribot.kb.chunker")
+
+TARGET_MIN = 400
+TARGET_MAX = 600
+HARD_MIN = 100
+HARD_MAX = 1000
+OVERLAP_RATIO = 0.125  # ~12.5%, centre of the 10-15% band
+PARENT_THRESHOLD = 1200  # spec §6
+PROCEDURE_WHOLE_LIMIT = 800
+STATUTE_ABSATZ_SPLIT = 2000
+
+# Historical blends better as smaller chunks (spec §5.3)
+HISTORICAL_MIN = 300
+HISTORICAL_MAX = 400
+
+
+@dataclass
+class Section:
+    """Structural unit emitted by the splitter — one heading + its body."""
+
+    heading: str
+    text: str
+    level: int  # 1..3
+
+
+@dataclass
+class Document:
+    """Input to ``chunk_document``."""
+
+    source_url: str
+    source_name: str
+    title: str
+    language: str
+    category: Category
+    authority: Authority
+    doc_type: DocType
+    # Either ``sections`` (structural input) or ``text`` (flat) must be set.
+    sections: list[Section] = field(default_factory=list)
+    text: str = ""
+    subcategory: Optional[str] = None
+    tags: list[str] = field(default_factory=list)
+    created_at: Optional[date] = None
+    updated_at: Optional[date] = None
+    ttl_days: Optional[int] = None
+    district: Optional[str] = None
+    license: Optional[str] = None
+    # doc_type-specific context
+    entity_name: Optional[str] = None
+    entity_type: Optional[str] = None
+    address: Optional[str] = None
+    law_name: Optional[str] = None
+    abbrev: Optional[str] = None
+    sr_number: Optional[str] = None
+    ls_number: Optional[str] = None
+    article_number: Optional[str] = None
+    period: Optional[str] = None
+
+
+# ── Sentence-safe text splitting ───────────────────────────────────────────
+
+_SENT_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[A-ZÄÖÜ])")
+_PARAGRAPH = re.compile(r"\n\s*\n")
+
+
+def _sentences(text: str) -> list[str]:
+    """Split to sentences. Good enough for DE + EN prose."""
+    text = text.strip()
+    if not text:
+        return []
+    return [s.strip() for s in _SENT_BOUNDARY.split(text) if s.strip()]
+
+
+def _pack_sentences(
+    sentences: list[str],
+    target_min: int,
+    target_max: int,
+    overlap_ratio: float,
+) -> list[str]:
+    """Pack sentences into chunks in the target token range with overlap.
+
+    Greedy: grow a chunk until adding the next sentence would exceed
+    target_max, then emit. Overlap = last N sentences re-used as the
+    start of the next chunk, sized by token ratio.
+    """
+    if not sentences:
+        return []
+
+    chunks: list[str] = []
+    cur: list[str] = []
+    cur_tokens = 0
+
+    i = 0
+    while i < len(sentences):
+        s = sentences[i]
+        s_tokens = count_tokens(s)
+
+        # Guard: a single sentence bigger than hard max gets emitted alone.
+        if s_tokens > HARD_MAX:
+            if cur:
+                chunks.append(" ".join(cur))
+                cur, cur_tokens = [], 0
+            chunks.append(s)
+            i += 1
+            continue
+
+        would_be = cur_tokens + s_tokens
+        if cur and would_be > target_max:
+            chunks.append(" ".join(cur))
+            # Seed next chunk with the tail of this one for overlap.
+            overlap_budget = int(target_max * overlap_ratio)
+            tail: list[str] = []
+            tail_tokens = 0
+            for prev in reversed(cur):
+                t = count_tokens(prev)
+                if tail_tokens + t > overlap_budget:
+                    break
+                tail.insert(0, prev)
+                tail_tokens += t
+            cur = tail
+            cur_tokens = tail_tokens
+            continue
+
+        cur.append(s)
+        cur_tokens += s_tokens
+        i += 1
+
+    if cur and cur_tokens >= HARD_MIN:
+        chunks.append(" ".join(cur))
+    elif cur and chunks:
+        # Tail too small — fold into previous.
+        chunks[-1] = chunks[-1] + " " + " ".join(cur)
+    elif cur:
+        # Doc is just a single tiny bit; keep it anyway.
+        chunks.append(" ".join(cur))
+
+    return chunks
+
+
+# ── Heading path builders ──────────────────────────────────────────────────
+
+def _heading_path(doc: Document, *extra: str) -> str:
+    parts = [doc.source_name, doc.title, *[e for e in extra if e]]
+    return " > ".join(parts)
+
+
+# ── Per-doc_type chunkers ──────────────────────────────────────────────────
+
+def _chunk_article(doc: Document, target_min: int, target_max: int) -> list[tuple[str, str, Optional[str]]]:
+    """Return (display_text, heading_path_suffix, parent_ref_key) triples.
+
+    parent_ref_key is a key identifying which parent section the child
+    belongs to; it maps to an entry in the later parent-pass.
+    """
+    results: list[tuple[str, str, Optional[str]]] = []
+
+    sections = doc.sections or [Section(heading="", text=doc.text, level=2)]
+
+    for sec in sections:
+        section_tokens = count_tokens(sec.text)
+        parent_key: Optional[str] = None
+        if section_tokens > PARENT_THRESHOLD:
+            parent_key = sec.heading or "body"
+
+        sentences = _sentences(sec.text)
+        pieces = _pack_sentences(sentences, target_min, target_max, OVERLAP_RATIO)
+        for piece in pieces:
+            results.append((piece, sec.heading, parent_key))
+
+    return results
+
+
+def _chunk_procedure(doc: Document) -> list[tuple[str, str, Optional[int]]]:
+    """Whole if small; else one chunk per step, never splitting a step."""
+    whole = doc.text or "\n\n".join(s.text for s in doc.sections)
+    total = count_tokens(whole)
+    if total <= PROCEDURE_WHOLE_LIMIT and not doc.sections:
+        return [(whole.strip(), "", None)]
+
+    if doc.sections:
+        out: list[tuple[str, str, Optional[int]]] = []
+        for i, sec in enumerate(doc.sections):
+            out.append((sec.text.strip(), sec.heading, i))
+        return out
+
+    # Flat procedure text above the whole-limit: fall back to article packing.
+    pieces = _pack_sentences(
+        _sentences(whole), TARGET_MIN, TARGET_MAX, OVERLAP_RATIO,
+    )
+    return [(p, "", i) for i, p in enumerate(pieces)]
+
+
+def _chunk_reference(doc: Document) -> list[tuple[str, str]]:
+    """One entity = one chunk. Never split."""
+    text = doc.text or "\n".join(s.text for s in doc.sections)
+    return [(text.strip(), "")]
+
+
+def _chunk_statute(doc: Document) -> list[tuple[str, str, Optional[str]]]:
+    """One article = one chunk; split on Absatz boundaries if >2000 tokens."""
+    text = (doc.text or "\n".join(s.text for s in doc.sections)).strip()
+    tokens = count_tokens(text)
+    if tokens <= STATUTE_ABSATZ_SPLIT:
+        return [(text, "", None)]
+
+    # Split on Absatz markers like "1 " / "2 " or "Abs. 1".
+    absatz_split = re.split(r"(?=^\s*\d+\s)", text, flags=re.MULTILINE)
+    out = [(part.strip(), "", str(i + 1)) for i, part in enumerate(absatz_split) if part.strip()]
+    return out or [(text, "", None)]
+
+
+def _chunk_historical(doc: Document) -> list[tuple[str, str, Optional[str]]]:
+    """Same as article but with smaller target range."""
+    return _chunk_article(doc, HISTORICAL_MIN, HISTORICAL_MAX)
+
+
+# ── Public entry point ────────────────────────────────────────────────────
+
+def chunk_document(doc: Document) -> list[Chunk]:
+    """Chunk a document according to its doc_type. Returns Chunk objects.
+
+    The caller is responsible for constructing the Document with the
+    appropriate sections (from HTML parsing) or flat text.
+    """
+    if not doc.sections and not doc.text:
+        raise ValueError("Document must have either sections or text")
+    if doc.created_at is None or doc.updated_at is None:
+        raise ValueError("created_at and updated_at are required")
+
+    doc_id = make_doc_id(doc.source_url, doc.language)
+
+    dispatch = {
+        "article": lambda: _chunk_article(doc, TARGET_MIN, TARGET_MAX),
+        "historical": lambda: _chunk_historical(doc),
+        "procedure": lambda: _chunk_procedure(doc),
+        "reference": lambda: _chunk_reference(doc),
+        "statute": lambda: _chunk_statute(doc),
+    }
+    raw = dispatch[doc.doc_type]()
+
+    # Collect parent sections first (article / historical only).
+    parent_map: dict[str, str] = {}
+    if doc.doc_type in ("article", "historical"):
+        for sec in doc.sections:
+            if count_tokens(sec.text) > PARENT_THRESHOLD:
+                parent_map[sec.heading or "body"] = sec.text.strip()
+
+    chunks: list[Chunk] = []
+    parent_chunk_ids: dict[str, str] = {}
+
+    # Emit parent chunks first so children can reference them.
+    for i, (key, text) in enumerate(parent_map.items(), start=1):
+        pidx = f"P{i:02d}"
+        pid = make_chunk_id(doc_id, pidx)
+        parent_chunk_ids[key] = pid
+        heading = key if key != "body" else ""
+        hp = _heading_path(doc, heading) if heading else _heading_path(doc)
+        chunks.append(_build(doc, doc_id, pidx, None, text, heading, hp))
+
+    # Emit children.
+    for idx, entry in enumerate(raw):
+        if doc.doc_type in ("article", "historical"):
+            piece, heading, parent_key = entry
+            parent_id = parent_chunk_ids.get(parent_key) if parent_key else None
+            step_index = None
+            paragraph = None
+        elif doc.doc_type == "procedure":
+            piece, heading, step_index = entry
+            parent_id = None
+            paragraph = None
+        elif doc.doc_type == "statute":
+            piece, heading, paragraph = entry
+            parent_id = None
+            step_index = None
+        else:  # reference
+            piece, heading = entry
+            parent_id = None
+            step_index = None
+            paragraph = None
+
+        hp = _heading_path(doc, heading) if heading else _heading_path(doc)
+        chunks.append(_build(
+            doc, doc_id, idx, parent_id, piece, heading, hp,
+            step_index=step_index, paragraph=paragraph,
+        ))
+
+    return chunks
+
+
+def _build(
+    doc: Document,
+    doc_id: str,
+    chunk_index: int | str,
+    parent_chunk_id: Optional[str],
+    display_text: str,
+    section_heading: str,
+    heading_path: str,
+    *,
+    step_index: Optional[int] = None,
+    paragraph: Optional[str] = None,
+) -> Chunk:
+    embed_text = f"{heading_path}\n\n{display_text}"
+    return Chunk(
+        chunk_id=make_chunk_id(doc_id, chunk_index),
+        doc_id=doc_id,
+        chunk_index=chunk_index,
+        parent_chunk_id=parent_chunk_id,
+        source_url=doc.source_url,
+        source_name=doc.source_name,
+        title=doc.title,
+        heading_path=heading_path,
+        language=doc.language,
+        category=doc.category,
+        subcategory=doc.subcategory,
+        authority=doc.authority,
+        doc_type=doc.doc_type,
+        chunk_shape="prose",
+        token_count=count_tokens(display_text),
+        tags=doc.tags,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
+        ttl_days=doc.ttl_days,
+        display_text=display_text,
+        embed_text=embed_text,
+        step_index=step_index,
+        entity_name=doc.entity_name,
+        entity_type=doc.entity_type,
+        address=doc.address,
+        law_name=doc.law_name,
+        abbrev=doc.abbrev,
+        sr_number=doc.sr_number,
+        ls_number=doc.ls_number,
+        article_number=doc.article_number,
+        paragraph=paragraph,
+        period=doc.period,
+        district=doc.district,
+        license=doc.license,
+    )

--- a/backend/kb/fetchers.py
+++ b/backend/kb/fetchers.py
@@ -1,0 +1,87 @@
+"""HTTP fetcher with per-domain rate limiting.
+
+Playwright fallback for JS-heavy sites (stadt-zuerich.ch and friends)
+is declared in the API but not yet implemented — spec §12. When the
+first ingester that needs it lands, add playwright to requirements and
+fill in ``fetch_rendered``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+logger = logging.getLogger("zuribot.kb.fetchers")
+
+DEFAULT_UA = (
+    "Mozilla/5.0 (compatible; BuenzliBot/0.1; +https://buenzli.space/bot) "
+    "KB-ingest"
+)
+
+
+@dataclass
+class FetchResult:
+    url: str
+    status_code: int
+    content: bytes
+    content_type: str
+    final_url: str  # after redirects
+
+
+class Fetcher:
+    """Per-domain rate-limited HTTP client. One instance per ingest run."""
+
+    def __init__(
+        self,
+        rate_limit_seconds: float = 1.5,
+        timeout: int = 15,
+        user_agent: str = DEFAULT_UA,
+    ):
+        self.rate_limit = rate_limit_seconds
+        self.timeout = timeout
+        self._last_request: dict[str, float] = {}
+        self._session = requests.Session()
+        self._session.headers.update({
+            "User-Agent": user_agent,
+            "Accept": "text/html,application/xhtml+xml,application/pdf",
+            "Accept-Language": "de,en;q=0.9",
+        })
+
+    def fetch(self, url: str) -> Optional[FetchResult]:
+        """GET ``url`` with per-domain throttling. Returns None on failure."""
+        domain = urlparse(url).netloc
+        last = self._last_request.get(domain, 0.0)
+        elapsed = time.time() - last
+        if elapsed < self.rate_limit:
+            time.sleep(self.rate_limit - elapsed)
+
+        try:
+            resp = self._session.get(
+                url, timeout=self.timeout, allow_redirects=True,
+            )
+        except requests.RequestException as e:
+            logger.warning("fetch failed url=%s err=%s", url, e)
+            self._last_request[domain] = time.time()
+            return None
+
+        self._last_request[domain] = time.time()
+        return FetchResult(
+            url=url,
+            status_code=resp.status_code,
+            content=resp.content,
+            content_type=resp.headers.get("Content-Type", ""),
+            final_url=resp.url,
+        )
+
+    def fetch_rendered(self, url: str) -> Optional[FetchResult]:
+        """Playwright-rendered fetch — not yet implemented. See spec §12."""
+        raise NotImplementedError(
+            "Playwright fallback not wired yet. Add playwright to "
+            "requirements and implement when the first stadt-zuerich.ch "
+            "ingester lands."
+        )

--- a/backend/kb/metadata.py
+++ b/backend/kb/metadata.py
@@ -1,0 +1,128 @@
+"""Chunk metadata schema — pydantic model + ID helpers.
+
+Spec: docs/knowledge_base.md §7 and §9.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import date
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+SCHEMA_VERSION = 1
+
+DocType = Literal["article", "procedure", "reference", "statute", "historical"]
+ChunkShape = Literal["prose", "table", "list", "code"]
+Authority = Literal[
+    "federal", "cantonal", "city", "wikipedia", "community", "private",
+]
+Category = Literal[
+    "admin", "housing", "mobility", "health", "emergency", "education",
+    "civic", "leisure", "food_drink", "neighborhoods", "law",
+]
+
+_SUBCATEGORY_RE = re.compile(r"^[a-z_]+/[a-z0-9_]+$")
+
+
+def make_doc_id(source_url: str, language: str) -> str:
+    """Stable 12-char doc id. Same URL+lang always hashes to the same id."""
+    key = f"{source_url}|{language}|{SCHEMA_VERSION}"
+    return hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+
+
+def make_chunk_id(doc_id: str, chunk_index: int | str) -> str:
+    """Zero-padded child chunk id, or passthrough for parent ('P01') ids."""
+    if isinstance(chunk_index, str):
+        return f"{doc_id}_{chunk_index}"
+    return f"{doc_id}_{chunk_index:04d}"
+
+
+class Chunk(BaseModel):
+    """One chunk = one Qdrant point (in Phase 2)."""
+
+    # Identity
+    chunk_id: str
+    doc_id: str
+    chunk_index: int | str  # int for children, "P01"/"P02" for parents
+    parent_chunk_id: Optional[str] = None
+
+    # Source
+    source_url: str
+    source_name: str
+    title: str
+    heading_path: str
+
+    # Classification
+    language: str
+    category: Category
+    subcategory: Optional[str] = None
+    authority: Authority
+    doc_type: DocType
+    chunk_shape: ChunkShape = "prose"
+
+    # Sizing
+    token_count: int = Field(ge=0)
+
+    # Freeform
+    tags: list[str] = Field(default_factory=list)
+
+    # Freshness
+    created_at: date
+    updated_at: date
+    ttl_days: Optional[int] = None
+
+    # Schema tracking
+    schema_version: int = SCHEMA_VERSION
+
+    # Payload
+    display_text: str
+    embed_text: str
+
+    # Optional per-doc_type
+    step_index: Optional[int] = None
+    entity_name: Optional[str] = None
+    entity_type: Optional[str] = None
+    address: Optional[str] = None
+    law_name: Optional[str] = None
+    abbrev: Optional[str] = None
+    sr_number: Optional[str] = None
+    ls_number: Optional[str] = None
+    article_number: Optional[str] = None
+    paragraph: Optional[str] = None
+    period: Optional[str] = None
+
+    # Cross-cutting optional
+    district: Optional[str] = None
+    license: Optional[str] = None
+
+    @field_validator("subcategory")
+    @classmethod
+    def _subcategory_shape(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not _SUBCATEGORY_RE.match(v):
+            raise ValueError(
+                f"subcategory must be 'category/leaf' lowercase: {v!r}"
+            )
+        return v
+
+    @field_validator("language")
+    @classmethod
+    def _language_is_iso(cls, v: str) -> str:
+        if not re.match(r"^[a-z]{2,3}$", v):
+            raise ValueError(f"language must be 2-3 letter ISO code: {v!r}")
+        return v
+
+    @field_validator("heading_path")
+    @classmethod
+    def _heading_path_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("heading_path must not be empty (spec §5.5)")
+        return v
+
+    def to_jsonl(self) -> str:
+        """Single-line JSON serialisation for the Phase 1 .jsonl output."""
+        return self.model_dump_json(exclude_none=False)

--- a/backend/kb/tokenizer.py
+++ b/backend/kb/tokenizer.py
@@ -1,0 +1,48 @@
+"""EmbeddingGemma tokenizer — used in Phase 1 to count tokens only.
+
+Loads the tokenizer from `google/embeddinggemma-300m` (HuggingFace). The
+tokenizer file is ~2 MB; no model weights are loaded. Cached in
+``~/.cache/huggingface`` after first fetch.
+
+Why the model's own tokenizer and not tiktoken: embedding quality
+degrades sharply past EmbeddingGemma's sweet spot (~500 tokens) and
+fails past its 2048-token input limit. Using Gemma's tokenizer makes
+our Phase-1 token budgets *truth* rather than approximations. See
+docs/knowledge_base.md §5.2 and §8.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+
+logger = logging.getLogger("zuribot.kb.tokenizer")
+
+_MODEL_ID = "google/embeddinggemma-300m"
+
+
+@lru_cache(maxsize=1)
+def _tokenizer():
+    from tokenizers import Tokenizer
+
+    token = os.getenv("HF_TOKEN")
+    try:
+        tk = Tokenizer.from_pretrained(_MODEL_ID, auth_token=token) if token else \
+             Tokenizer.from_pretrained(_MODEL_ID)
+        logger.info("Loaded EmbeddingGemma tokenizer from %s", _MODEL_ID)
+        return tk
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to load EmbeddingGemma tokenizer from '{_MODEL_ID}'. "
+            f"Gemma models are gated on HuggingFace — set HF_TOKEN in the "
+            f"environment after accepting the model license at "
+            f"https://huggingface.co/{_MODEL_ID}. Underlying error: {e}"
+        ) from e
+
+
+def count_tokens(text: str) -> int:
+    """Return token count for ``text`` under EmbeddingGemma's tokenizer."""
+    if not text:
+        return 0
+    return len(_tokenizer().encode(text).ids)

--- a/backend/kb/writers.py
+++ b/backend/kb/writers.py
@@ -1,0 +1,52 @@
+"""JSONL writer for Phase 1 chunk output.
+
+One file per (category, source) pair. Appends validated Chunk objects
+as single-line JSON. Directory layout:
+
+    data/chunks/{category}/{source}/{doc_id}.jsonl
+
+Spec: docs/knowledge_base.md §13.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from backend.kb.metadata import Chunk
+
+logger = logging.getLogger("zuribot.kb.writers")
+
+
+def write_chunks(
+    chunks: Iterable[Chunk],
+    root: Path,
+    category: str,
+    source_slug: str,
+) -> Path:
+    """Write ``chunks`` for one doc to ``root/category/source_slug/{doc_id}.jsonl``.
+
+    Overwrites any existing file for the same doc_id. Returns the path.
+    All chunks must share a doc_id; raises ValueError if not.
+    """
+    chunks = list(chunks)
+    if not chunks:
+        raise ValueError("write_chunks called with empty iterable")
+
+    doc_ids = {c.doc_id for c in chunks}
+    if len(doc_ids) != 1:
+        raise ValueError(f"write_chunks expects one doc_id, got {doc_ids}")
+    doc_id = doc_ids.pop()
+
+    out_dir = root / category / source_slug
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{doc_id}.jsonl"
+
+    with path.open("w", encoding="utf-8") as f:
+        for chunk in chunks:
+            f.write(chunk.to_jsonl())
+            f.write("\n")
+
+    logger.info("Wrote %d chunks for doc %s -> %s", len(chunks), doc_id, path)
+    return path

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ beautifulsoup4>=4.12.0
 pandas>=2.0.0
 PyJWT[crypto]>=2.8.0
 httpx>=0.27.0
+# KB Phase 1 — tokenizer only, used for counting (not embedding).
+tokenizers>=0.15.0

--- a/tests/kb/conftest.py
+++ b/tests/kb/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures — stub the tokenizer so tests run without HF access.
+
+Real token counts vary with the model's tokenizer. For structure-level
+tests we only need a deterministic, reasonable approximation. We use a
+whitespace-word count (multiplied for German compound words) as a
+stand-in. Integration tests that actually need the Gemma tokenizer
+should set HF_TOKEN and call ``count_tokens`` directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _fake_count(text: str) -> int:
+    # ~1.3 tokens per whitespace-word is a reasonable DE/EN average.
+    if not text:
+        return 0
+    words = text.split()
+    return int(len(words) * 1.3) or 1
+
+
+@pytest.fixture(autouse=True)
+def _stub_tokenizer(monkeypatch):
+    monkeypatch.setattr(
+        "backend.kb.tokenizer.count_tokens", _fake_count, raising=True,
+    )
+    monkeypatch.setattr(
+        "backend.kb.chunker.count_tokens", _fake_count, raising=True,
+    )

--- a/tests/kb/test_chunker.py
+++ b/tests/kb/test_chunker.py
@@ -1,0 +1,123 @@
+"""Smoke tests for chunker behaviour across doc_types."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from backend.kb.chunker import Document, Section, chunk_document
+
+
+def _base_doc(**overrides) -> Document:
+    base = dict(
+        source_url="https://example.ch/x",
+        source_name="Example",
+        title="Demo",
+        language="de",
+        category="admin",
+        authority="federal",
+        doc_type="article",
+        created_at=date(2025, 1, 1),
+        updated_at=date(2025, 6, 1),
+    )
+    base.update(overrides)
+    return Document(**base)
+
+
+_LOREM = (
+    "Die Schweiz ist ein föderaler Bundesstaat. Sie besteht aus 26 Kantonen. "
+    "Zürich ist der bevölkerungsreichste Kanton. "
+)
+
+
+def test_article_produces_valid_chunks():
+    doc = _base_doc(sections=[Section("Übersicht", _LOREM * 50, 2)])
+    chunks = chunk_document(doc)
+    assert chunks, "chunker produced zero chunks"
+    for c in chunks:
+        assert c.doc_type == "article"
+        assert "Example > Demo" in c.heading_path
+        assert c.embed_text.startswith(c.heading_path)
+        assert c.token_count > 0
+
+
+def test_article_parent_child_emitted_for_long_sections():
+    # One huge section should trigger a parent chunk.
+    huge = _LOREM * 200
+    doc = _base_doc(sections=[Section("Dossier", huge, 2)])
+    chunks = chunk_document(doc)
+    parents = [c for c in chunks if isinstance(c.chunk_index, str) and c.chunk_index.startswith("P")]
+    children_with_parent = [c for c in chunks if c.parent_chunk_id]
+    assert parents, "expected at least one parent chunk"
+    assert children_with_parent, "expected at least one child linked to parent"
+    assert children_with_parent[0].parent_chunk_id == parents[0].chunk_id
+
+
+def test_reference_never_splits():
+    doc = _base_doc(
+        doc_type="reference",
+        text=_LOREM * 100,
+        entity_name="USZ",
+        entity_type="hospital",
+    )
+    chunks = chunk_document(doc)
+    assert len(chunks) == 1
+    assert chunks[0].entity_name == "USZ"
+
+
+def test_procedure_whole_when_short():
+    doc = _base_doc(doc_type="procedure", text=_LOREM * 5)
+    chunks = chunk_document(doc)
+    assert len(chunks) == 1
+    assert chunks[0].step_index is None
+
+
+def test_procedure_splits_on_step_sections():
+    steps = [Section(f"Schritt {i}", _LOREM * 10, 3) for i in range(1, 4)]
+    doc = _base_doc(doc_type="procedure", sections=steps)
+    chunks = chunk_document(doc)
+    assert len(chunks) == 3
+    assert [c.step_index for c in chunks] == [0, 1, 2]
+    assert all("Schritt" in c.heading_path for c in chunks)
+
+
+def test_statute_single_article_is_one_chunk():
+    doc = _base_doc(
+        doc_type="statute",
+        category="law",
+        text="Jede Person hat Anspruch auf Leben.",
+        law_name="Bundesverfassung",
+        abbrev="BV",
+        sr_number="101",
+        article_number="10",
+    )
+    chunks = chunk_document(doc)
+    assert len(chunks) == 1
+    assert chunks[0].article_number == "10"
+    assert chunks[0].paragraph is None
+
+
+def test_historical_uses_smaller_chunk_target():
+    doc = _base_doc(doc_type="historical", sections=[Section("Geschichte", _LOREM * 60, 2)])
+    chunks = chunk_document(doc)
+    assert chunks
+    # Historical chunks should be smaller on average than article chunks for
+    # the same input. Compare:
+    article_doc = _base_doc(sections=[Section("Geschichte", _LOREM * 60, 2)])
+    article_chunks = chunk_document(article_doc)
+    avg_hist = sum(c.token_count for c in chunks) / len(chunks)
+    avg_art = sum(c.token_count for c in article_chunks) / len(article_chunks)
+    assert avg_hist < avg_art
+
+
+def test_chunk_ids_are_unique_per_doc():
+    doc = _base_doc(sections=[Section("A", _LOREM * 20, 2), Section("B", _LOREM * 20, 2)])
+    chunks = chunk_document(doc)
+    ids = [c.chunk_id for c in chunks]
+    assert len(ids) == len(set(ids))
+
+
+def test_doc_without_text_or_sections_raises():
+    with pytest.raises(ValueError):
+        chunk_document(_base_doc())

--- a/tests/kb/test_metadata.py
+++ b/tests/kb/test_metadata.py
@@ -1,0 +1,84 @@
+"""Smoke tests for the chunk metadata schema + ID helpers."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from backend.kb.metadata import (
+    SCHEMA_VERSION,
+    Chunk,
+    make_chunk_id,
+    make_doc_id,
+)
+
+
+def _base_kwargs(**overrides):
+    base = dict(
+        chunk_id="abc123abc123_0001",
+        doc_id="abc123abc123",
+        chunk_index=1,
+        source_url="https://www.ch.ch/de/umzug/",
+        source_name="ch.ch",
+        title="Umzug",
+        heading_path="ch.ch > Wohnen > Umzug",
+        language="de",
+        category="admin",
+        authority="federal",
+        doc_type="procedure",
+        token_count=123,
+        created_at=date(2025, 1, 1),
+        updated_at=date(2025, 6, 1),
+        display_text="Beim Umzug müssen Sie sich abmelden.",
+        embed_text="ch.ch > Wohnen > Umzug\n\nBeim Umzug müssen Sie sich abmelden.",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_doc_id_is_stable():
+    a = make_doc_id("https://ch.ch/de/umzug/", "de")
+    b = make_doc_id("https://ch.ch/de/umzug/", "de")
+    assert a == b
+    assert len(a) == 12
+
+
+def test_doc_id_differs_by_url_and_language():
+    assert make_doc_id("https://a.ch/", "de") != make_doc_id("https://a.ch/", "en")
+    assert make_doc_id("https://a.ch/", "de") != make_doc_id("https://b.ch/", "de")
+
+
+def test_chunk_id_padding():
+    assert make_chunk_id("abc", 7) == "abc_0007"
+    assert make_chunk_id("abc", "P02") == "abc_P02"
+
+
+def test_chunk_schema_valid():
+    c = Chunk(**_base_kwargs())
+    assert c.schema_version == SCHEMA_VERSION
+    assert c.chunk_shape == "prose"
+    assert c.tags == []
+
+
+def test_chunk_rejects_bad_subcategory():
+    with pytest.raises(ValidationError):
+        Chunk(**_base_kwargs(subcategory="Admin/Umzug"))
+
+
+def test_chunk_rejects_bad_language():
+    with pytest.raises(ValidationError):
+        Chunk(**_base_kwargs(language="german"))
+
+
+def test_chunk_rejects_empty_heading_path():
+    with pytest.raises(ValidationError):
+        Chunk(**_base_kwargs(heading_path=""))
+
+
+def test_chunk_to_jsonl_is_single_line():
+    c = Chunk(**_base_kwargs())
+    line = c.to_jsonl()
+    assert "\n" not in line
+    assert line.startswith("{") and line.endswith("}")

--- a/tests/kb/test_writers.py
+++ b/tests/kb/test_writers.py
@@ -1,0 +1,55 @@
+"""Smoke tests for the JSONL writer."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from backend.kb.metadata import Chunk
+from backend.kb.writers import write_chunks
+
+
+def _chunk(doc_id: str = "aaa111bbb222", idx: int = 0) -> Chunk:
+    return Chunk(
+        chunk_id=f"{doc_id}_{idx:04d}",
+        doc_id=doc_id,
+        chunk_index=idx,
+        source_url="https://example.ch/x",
+        source_name="Example",
+        title="Demo",
+        heading_path="Example > Demo",
+        language="de",
+        category="admin",
+        authority="federal",
+        doc_type="article",
+        token_count=10,
+        created_at=date(2025, 1, 1),
+        updated_at=date(2025, 6, 1),
+        display_text="Text.",
+        embed_text="Example > Demo\n\nText.",
+    )
+
+
+def test_writes_jsonl_per_doc(tmp_path):
+    chunks = [_chunk(idx=i) for i in range(3)]
+    out = write_chunks(chunks, tmp_path, "admin", "example")
+    assert out.parent == tmp_path / "admin" / "example"
+    assert out.name == "aaa111bbb222.jsonl"
+    lines = out.read_text().splitlines()
+    assert len(lines) == 3
+    for line in lines:
+        parsed = json.loads(line)
+        assert parsed["doc_id"] == "aaa111bbb222"
+
+
+def test_rejects_empty(tmp_path):
+    with pytest.raises(ValueError):
+        write_chunks([], tmp_path, "admin", "example")
+
+
+def test_rejects_mixed_doc_ids(tmp_path):
+    chunks = [_chunk("aaa", 0), _chunk("bbb", 1)]
+    with pytest.raises(ValueError):
+        write_chunks(chunks, tmp_path, "admin", "example")


### PR DESCRIPTION
## Summary
- Implements step 1 of the KB rebuild build order in `docs/knowledge_base.md` §15.
- New module `backend/kb/` (704 lines): tokenizer, metadata schema, chunker, writer, fetcher stub.
- 20 smoke tests under `tests/kb/`, all green. Full suite: 30 passed.
- Adds `tokenizers` to `requirements.txt` — only dep needed for Phase 1 token counting.

## What the scaffold does
- **tokenizer.py**: loads EmbeddingGemma-300M's SentencePiece tokenizer (HF, ~2 MB, no model weights). Used as a ruler to count tokens correctly against the real model. Requires `HF_TOKEN` once per machine.
- **metadata.py**: pydantic `Chunk` model matching spec §7; stable SHA1-based `doc_id` / `chunk_id` helpers.
- **chunker.py**: structural splitter (H1→H2→H3 → paragraphs → sentences), 400–600 token target with 12.5% overlap, heading-path prefix for embedding, parent-child emission for long sections. Per-`doc_type` dispatch (article / procedure / reference / statute / historical).
- **writers.py**: validated JSONL append, one file per `doc_id` under `data/chunks/{category}/{source}/`.
- **fetchers.py**: per-domain rate-limited HTTP client. Playwright fallback declared but stubbed — lands when the first stadt-zuerich.ch ingester needs it.

## What's **not** in this PR
- No ingesters (ch.ch, law PDFs, Quartierspiegel, etc.) — next sessions.
- No Playwright dependency — deferred to first JS-site ingester.
- No Phase 2 (embedding, Qdrant) — needs the AI pod.

## Test plan
- [x] `pytest tests/kb/` — 20 green
- [x] Full suite — 30 green
- [x] `from tokenizers import Tokenizer` resolves in the app venv
- [ ] Real EmbeddingGemma tokenizer load (deferred — needs `HF_TOKEN`; first ingester session will validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)