### PR TITLE
kb: first ingester (ch.ch) + pipeline fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ data/manual_content/
 # Env backup (never commit)
 .env.save
 DEPLOY_NOTES.md
+data/chunks/

--- a/backend/kb/fetchers.py
+++ b/backend/kb/fetchers.py
@@ -78,10 +78,56 @@ class Fetcher:
             final_url=resp.url,
         )
 
-    def fetch_rendered(self, url: str) -> Optional[FetchResult]:
-        """Playwright-rendered fetch — not yet implemented. See spec §12."""
-        raise NotImplementedError(
-            "Playwright fallback not wired yet. Add playwright to "
-            "requirements and implement when the first stadt-zuerich.ch "
-            "ingester lands."
+    def fetch_rendered(
+        self,
+        url: str,
+        wait_until: str = "networkidle",
+        wait_ms: int = 0,
+    ) -> Optional[FetchResult]:
+        """Fetch ``url`` with headless Chromium. Use for JS-rendered sites.
+
+        Respects the same per-domain rate limit as ``fetch``. Returns the
+        fully-rendered HTML as bytes in ``content`` with
+        ``content_type='text/html; charset=utf-8'``.
+
+        Lazy-imports playwright so ingesters that only need static HTTP
+        don't pull in the heavy dep.
+        """
+        domain = urlparse(url).netloc
+        last = self._last_request.get(domain, 0.0)
+        elapsed = time.time() - last
+        if elapsed < self.rate_limit:
+            time.sleep(self.rate_limit - elapsed)
+
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as e:
+            raise RuntimeError(
+                "playwright not installed — add to requirements-heavy.txt "
+                "and run `python -m playwright install chromium`"
+            ) from e
+
+        try:
+            with sync_playwright() as p:
+                browser = p.chromium.launch(headless=True)
+                page = browser.new_page(user_agent=self._session.headers["User-Agent"])
+                resp = page.goto(url, wait_until=wait_until, timeout=self.timeout * 1000)
+                if wait_ms:
+                    page.wait_for_timeout(wait_ms)
+                html = page.content()
+                status = resp.status if resp else 0
+                final_url = page.url
+                browser.close()
+        except Exception as e:
+            logger.warning("rendered fetch failed url=%s err=%s", url, e)
+            self._last_request[domain] = time.time()
+            return None
+
+        self._last_request[domain] = time.time()
+        return FetchResult(
+            url=url,
+            status_code=status,
+            content=html.encode("utf-8"),
+            content_type="text/html; charset=utf-8",
+            final_url=final_url,
         )

--- a/backend/kb/fetchers.py
+++ b/backend/kb/fetchers.py
@@ -51,6 +51,31 @@ class Fetcher:
             "Accept": "text/html,application/xhtml+xml,application/pdf",
             "Accept-Language": "de,en;q=0.9",
         })
+        # Lazily-started persistent Playwright browser. Reused across
+        # fetch_rendered calls because launching Chromium costs ~3-5s.
+        self._pw = None
+        self._browser = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self) -> None:
+        """Tear down the cached Playwright browser, if any."""
+        if self._browser is not None:
+            try:
+                self._browser.close()
+            except Exception:
+                pass
+            self._browser = None
+        if self._pw is not None:
+            try:
+                self._pw.stop()
+            except Exception:
+                pass
+            self._pw = None
 
     def fetch(self, url: str) -> Optional[FetchResult]:
         """GET ``url`` with per-domain throttling. Returns None on failure."""
@@ -99,26 +124,33 @@ class Fetcher:
         if elapsed < self.rate_limit:
             time.sleep(self.rate_limit - elapsed)
 
-        try:
-            from playwright.sync_api import sync_playwright
-        except ImportError as e:
-            raise RuntimeError(
-                "playwright not installed — add to requirements-heavy.txt "
-                "and run `python -m playwright install chromium`"
-            ) from e
+        if self._browser is None:
+            try:
+                from playwright.sync_api import sync_playwright
+            except ImportError as e:
+                raise RuntimeError(
+                    "playwright not installed — add to requirements-heavy.txt "
+                    "and run `python -m playwright install chromium`"
+                ) from e
+            self._pw = sync_playwright().start()
+            self._browser = self._pw.chromium.launch(headless=True)
 
+        # Use Chromium's default UA — some sites (e.g. ch.ch) serve 404
+        # to identifiably-bot UAs even when rendered via a real browser.
+        page = self._browser.new_page()
         try:
-            with sync_playwright() as p:
-                browser = p.chromium.launch(headless=True)
-                page = browser.new_page(user_agent=self._session.headers["User-Agent"])
-                resp = page.goto(url, wait_until=wait_until, timeout=self.timeout * 1000)
-                if wait_ms:
-                    page.wait_for_timeout(wait_ms)
-                html = page.content()
-                status = resp.status if resp else 0
-                final_url = page.url
-                browser.close()
+            resp = page.goto(url, wait_until=wait_until, timeout=self.timeout * 1000)
+            if wait_ms:
+                page.wait_for_timeout(wait_ms)
+            html = page.content()
+            status = resp.status if resp else 0
+            final_url = page.url
+            page.close()
         except Exception as e:
+            try:
+                page.close()
+            except Exception:
+                pass
             logger.warning("rendered fetch failed url=%s err=%s", url, e)
             self._last_request[domain] = time.time()
             return None

--- a/backend/kb/tokenizer.py
+++ b/backend/kb/tokenizer.py
@@ -28,7 +28,7 @@ def _tokenizer():
 
     token = os.getenv("HF_TOKEN")
     try:
-        tk = Tokenizer.from_pretrained(_MODEL_ID, auth_token=token) if token else \
+        tk = Tokenizer.from_pretrained(_MODEL_ID, token=token) if token else \
              Tokenizer.from_pretrained(_MODEL_ID)
         logger.info("Loaded EmbeddingGemma tokenizer from %s", _MODEL_ID)
         return tk

--- a/requirements-heavy.txt
+++ b/requirements-heavy.txt
@@ -5,3 +5,6 @@ sentence-transformers>=3.0.0
 langchain-huggingface>=0.3.0
 chromadb>=1.0.0
 langchain-chroma>=0.2.0
+# Headless browser for JS-rendered sources (ch.ch, stadt-zuerich.ch, etc.).
+# Bundles a ~120 MB Chromium binary on first `playwright install`.
+playwright>=1.45.0

--- a/scripts/ingest/__init__.py
+++ b/scripts/ingest/__init__.py
@@ -1,0 +1,8 @@
+"""Per-source KB ingesters — Phase 1.
+
+Each module is a small, focused ingester that knows one source. Runs
+produce validated .jsonl under data/chunks/{category}/{source}/.
+
+Build order per spec §15. Start with ch.ch (first JS-rendered source),
+then federal law PDFs, then Quartierspiegel, then everything else.
+"""

--- a/scripts/ingest/_base.py
+++ b/scripts/ingest/_base.py
@@ -64,7 +64,16 @@ def extract_title_and_sections(
 
     def flush():
         if current_paragraphs:
-            text = "\n\n".join(p for p in current_paragraphs if p.strip())
+            # Dedupe: some sites (e.g. ch.ch) render desktop + mobile copies of
+            # the same content in one DOM, which doubles every paragraph.
+            seen: set[str] = set()
+            uniq = []
+            for p in current_paragraphs:
+                s = p.strip()
+                if s and s not in seen:
+                    seen.add(s)
+                    uniq.append(s)
+            text = "\n\n".join(uniq)
             if text.strip():
                 sections.append(Section(
                     heading=current_heading,

--- a/scripts/ingest/_base.py
+++ b/scripts/ingest/_base.py
@@ -1,0 +1,227 @@
+"""Shared helpers for per-source ingesters.
+
+Keeps individual ingester scripts tight: HTML extraction, paragraph
+collection into Sections, procedure/article heuristic, a simple BFS
+crawler.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from bs4 import BeautifulSoup, Tag
+
+from backend.kb.chunker import Document, Section, chunk_document
+from backend.kb.fetchers import FetchResult, Fetcher
+from backend.kb.metadata import Chunk
+from backend.kb.writers import write_chunks
+
+logger = logging.getLogger("zuribot.kb.ingest")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CHUNKS_ROOT = PROJECT_ROOT / "data" / "chunks"
+
+_PROCEDURE_HEADING_RE = re.compile(r"\b(schritt|etappe|step|étape|fase)\s*\d", re.IGNORECASE)
+_NUMBERED_LIST_RE = re.compile(r"(?m)^\s*\d+[\.\)]\s")
+
+
+# ── HTML extraction ────────────────────────────────────────────────────────
+
+def extract_title_and_sections(
+    html: bytes | str,
+    strip_selectors: Iterable[str] = (
+        "script", "style", "nav", "header", "footer", "aside",
+        "noscript", "form", "iframe",
+    ),
+    main_selector: str = "main",
+) -> tuple[str, list[Section], str]:
+    """Return (title, sections, full_text).
+
+    Sections are built by walking h2/h3 headings and collecting paragraphs
+    under each until the next heading. If no headings exist, one section
+    is emitted with heading='' and the full body text.
+
+    full_text is the concatenated body — useful for procedure heuristics.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for sel in strip_selectors:
+        for tag in soup.select(sel):
+            tag.decompose()
+
+    h1 = soup.find("h1")
+    title = h1.get_text(" ", strip=True) if h1 else ""
+
+    main = soup.select_one(main_selector) or soup.body or soup
+    sections: list[Section] = []
+    current_heading = ""
+    current_level = 2
+    current_paragraphs: list[str] = []
+
+    def flush():
+        if current_paragraphs:
+            text = "\n\n".join(p for p in current_paragraphs if p.strip())
+            if text.strip():
+                sections.append(Section(
+                    heading=current_heading,
+                    text=text,
+                    level=current_level,
+                ))
+
+    for el in main.descendants:
+        if not isinstance(el, Tag):
+            continue
+        name = el.name
+        if name in ("h2", "h3"):
+            flush()
+            current_heading = el.get_text(" ", strip=True)
+            current_level = 2 if name == "h2" else 3
+            current_paragraphs = []
+        elif name in ("p", "li"):
+            text = el.get_text(" ", strip=True)
+            if text:
+                current_paragraphs.append(text)
+    flush()
+
+    if not sections:
+        body_text = main.get_text("\n", strip=True)
+        if body_text:
+            sections = [Section(heading="", text=body_text, level=2)]
+
+    full_text = "\n\n".join(s.text for s in sections)
+    return title, sections, full_text
+
+
+def classify_doc_type(full_text: str, headings: list[str]) -> str:
+    """Return 'procedure' if the page looks step-shaped, else 'article'."""
+    if any(_PROCEDURE_HEADING_RE.search(h) for h in headings if h):
+        return "procedure"
+    if _NUMBERED_LIST_RE.search(full_text or ""):
+        return "procedure"
+    return "article"
+
+
+# ── BFS crawler ────────────────────────────────────────────────────────────
+
+@dataclass
+class CrawlConfig:
+    seeds: list[str]
+    url_prefix: str                 # only URLs starting with this are followed
+    max_pages: int = 200
+    max_depth: int = 3
+    render: bool = True             # True = Playwright, False = plain HTTP
+    link_filter: Optional[Callable[[str], bool]] = None
+
+
+def crawl(fetcher: Fetcher, cfg: CrawlConfig) -> list[FetchResult]:
+    """BFS-crawl from ``cfg.seeds`` under ``cfg.url_prefix``. Returns results."""
+    seen: set[str] = set()
+    frontier: list[tuple[str, int]] = [(u, 0) for u in cfg.seeds]
+    results: list[FetchResult] = []
+
+    while frontier and len(results) < cfg.max_pages:
+        url, depth = frontier.pop(0)
+        if url in seen:
+            continue
+        seen.add(url)
+
+        fn = fetcher.fetch_rendered if cfg.render else fetcher.fetch
+        res = fn(url)
+        if res is None or res.status_code != 200:
+            logger.info("skip url=%s status=%s", url, res and res.status_code)
+            continue
+
+        results.append(res)
+        logger.info("crawled %d/%d  %s", len(results), cfg.max_pages, url)
+
+        if depth >= cfg.max_depth:
+            continue
+
+        soup = BeautifulSoup(res.content, "html.parser")
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if href.startswith("/"):
+                href = f"https://{res.final_url.split('/')[2]}{href}"
+            if not href.startswith(cfg.url_prefix):
+                continue
+            href = href.split("#")[0].rstrip("/")
+            if cfg.link_filter and not cfg.link_filter(href):
+                continue
+            if href not in seen:
+                frontier.append((href, depth + 1))
+
+    return results
+
+
+# ── Document assembly + writing ────────────────────────────────────────────
+
+def make_and_write(
+    *,
+    category: str,
+    source_slug: str,
+    source_name: str,
+    authority: str,
+    language: str,
+    results: list[FetchResult],
+    title_transform: Optional[Callable[[str, str], str]] = None,
+    tags_for: Optional[Callable[[str, str], list[str]]] = None,
+    subcategory_for: Optional[Callable[[str], Optional[str]]] = None,
+    ttl_days: Optional[int] = None,
+) -> dict:
+    """Extract, classify, chunk, and write every result. Returns summary dict."""
+    today = date.today()
+    total_chunks = 0
+    docs_written = 0
+    procedures = 0
+    articles = 0
+
+    for res in results:
+        title, sections, full_text = extract_title_and_sections(res.content)
+        if not title or len(full_text) < 300:
+            logger.info("skip (no content) url=%s", res.url)
+            continue
+        if title_transform:
+            title = title_transform(title, res.url)
+
+        headings = [s.heading for s in sections]
+        doc_type = classify_doc_type(full_text, headings)
+        if doc_type == "procedure":
+            procedures += 1
+        else:
+            articles += 1
+
+        doc = Document(
+            source_url=res.final_url or res.url,
+            source_name=source_name,
+            title=title,
+            language=language,
+            category=category,  # type: ignore[arg-type]
+            authority=authority,  # type: ignore[arg-type]
+            doc_type=doc_type,  # type: ignore[arg-type]
+            sections=sections,
+            subcategory=subcategory_for(res.url) if subcategory_for else None,
+            tags=tags_for(title, full_text) if tags_for else [],
+            created_at=today,
+            updated_at=today,
+            ttl_days=ttl_days,
+        )
+        try:
+            chunks: list[Chunk] = chunk_document(doc)
+        except Exception as e:
+            logger.warning("chunk failed url=%s err=%s", res.url, e)
+            continue
+
+        write_chunks(chunks, CHUNKS_ROOT, category, source_slug)
+        docs_written += 1
+        total_chunks += len(chunks)
+
+    return {
+        "docs_written": docs_written,
+        "total_chunks": total_chunks,
+        "procedures": procedures,
+        "articles": articles,
+    }

--- a/scripts/ingest/ch_ch.py
+++ b/scripts/ingest/ch_ch.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""ch.ch ingester — federal citizen portal.
+
+Why Playwright: ch.ch is a client-rendered Nuxt 3 SPA. Plain HTTP
+yields a ~42 KB empty shell with the text "Suche starten". Only a
+real browser (via Playwright) sees the content.
+
+URL discovery: no public sitemap, mega-menu is JS-gated and doesn't
+expand on programmatic click. We BFS-crawl from a curated seed list
+of top-level topics with depth 3 and a page cap. Coverage is
+intentionally imperfect on the first pass — hardening URL-discovery
+is a separate follow-up.
+
+Scope: German (`/de/…`) only this first pass. Categories we fill:
+admin (most), health (some), mobility (some), education (some).
+Page-level ``category`` is chosen from the URL's topic segment.
+
+Usage:
+    python -m scripts.ingest.ch_ch                  # default run, ~100 pages
+    python -m scripts.ingest.ch_ch --limit 30       # small smoke run
+    python -m scripts.ingest.ch_ch --depth 2        # shallower crawl
+    python -m scripts.ingest.ch_ch --dry-run        # list discovered URLs, no chunking
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Optional
+
+from backend.kb.fetchers import Fetcher
+from scripts.ingest._base import CrawlConfig, crawl, make_and_write
+
+logger = logging.getLogger("zuribot.kb.ingest.ch_ch")
+
+SOURCE_NAME = "ch.ch — Bundesportal"
+SOURCE_SLUG = "ch_ch"
+AUTHORITY = "federal"
+LANGUAGE = "de"
+URL_PREFIX = "https://www.ch.ch/de/"
+TTL_DAYS = 180
+
+# Curated seeds — top-level topics on the DE site.
+SEEDS = [
+    "https://www.ch.ch/de/",
+    "https://www.ch.ch/de/fahrzeuge-und-verkehr",
+    "https://www.ch.ch/de/wohnen",
+    "https://www.ch.ch/de/arbeit",
+    "https://www.ch.ch/de/familie",
+    "https://www.ch.ch/de/gesundheit",
+    "https://www.ch.ch/de/bildung",
+    "https://www.ch.ch/de/migration",
+    "https://www.ch.ch/de/sozialversicherungen",
+    "https://www.ch.ch/de/steuern-und-finanzen",
+    "https://www.ch.ch/de/rechtssystem",
+]
+
+# Each URL's first topic segment maps to our KB category.
+TOPIC_TO_CATEGORY = {
+    "fahrzeuge-und-verkehr": "mobility",
+    "wohnen": "housing",
+    "arbeit": "admin",
+    "familie": "admin",
+    "gesundheit": "health",
+    "bildung": "education",
+    "migration": "admin",
+    "sozialversicherungen": "admin",
+    "steuern-und-finanzen": "admin",
+    "steuern": "admin",
+    "rechtssystem": "civic",
+    "fluchtlinge": "admin",
+}
+
+# Don't follow these — aren't citizen-facing content pages.
+SKIP_PATH_PREFIXES = (
+    "/de/s/",           # search
+    "/de/aktuell",      # news / highlights
+    "/de/uber-chch",    # about
+    "/de/rechtliches",  # disclaimer
+    "/de/voteinfo",
+    "/de/volksabstimmung",
+)
+
+
+def _expand_seeds(topic_urls: list[str], timeout_s: int = 30) -> list[str]:
+    """Click each sub-category button on each topic page; collect leaf URLs.
+
+    ch.ch's topic landing pages render sub-categories as <button> elements
+    (not <a>). Clicking one reveals that sub-category's leaf pages as
+    anchors — but navigating away, so we re-goto the topic between clicks.
+    Without this, a plain BFS only reaches the 11 seed topics.
+    """
+    from playwright.sync_api import sync_playwright
+
+    leaves: set[str] = set()
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        for topic in topic_urls:
+            try:
+                page.goto(topic, wait_until="networkidle", timeout=timeout_s * 1000)
+                page.wait_for_timeout(600)
+                labels = page.evaluate(
+                    """Array.from(new Set(
+                        Array.from(document.querySelectorAll('main button'))
+                          .filter(b => (b.innerText||'').trim() && !b.getAttribute('aria-label'))
+                          .map(b => b.innerText.trim())
+                    ))"""
+                )
+                for lbl in labels:
+                    try:
+                        page.goto(topic, wait_until="networkidle", timeout=timeout_s * 1000)
+                        page.wait_for_timeout(400)
+                        page.get_by_role("button", name=lbl, exact=True).first.click(timeout=3000)
+                        page.wait_for_timeout(500)
+                        hs = page.evaluate(
+                            """Array.from(document.querySelectorAll('a[href]')).map(a => a.getAttribute('href'))"""
+                        )
+                        for h in hs or []:
+                            if h and h.startswith("/de/") and h.count("/") >= 5:
+                                leaves.add(f"https://www.ch.ch{h}".rstrip("/"))
+                    except Exception as e:
+                        logger.info("expand %s / %r failed: %s", topic, lbl, e)
+            except Exception as e:
+                logger.info("topic %s failed: %s", topic, e)
+        browser.close()
+    return sorted(leaves)
+
+
+def _link_ok(url: str) -> bool:
+    path = url.replace("https://www.ch.ch", "", 1)
+    if any(path.startswith(p) for p in SKIP_PATH_PREFIXES):
+        return False
+    return True
+
+
+def _category_for(url: str) -> Optional[str]:
+    rest = url.removeprefix(URL_PREFIX).split("/")
+    if not rest or not rest[0]:
+        return None
+    return TOPIC_TO_CATEGORY.get(rest[0])
+
+
+def _subcategory_for(url: str) -> Optional[str]:
+    cat = _category_for(url)
+    if not cat:
+        return None
+    parts = url.removeprefix(URL_PREFIX).split("/")
+    if len(parts) >= 2 and parts[1]:
+        leaf = parts[1].replace("-", "_")
+        leaf = "".join(ch for ch in leaf if ch.isalnum() or ch == "_")
+        if leaf:
+            return f"{cat}/{leaf}"
+    return None
+
+
+def _tags_for(title: str, text: str) -> list[str]:
+    # Light heuristic — the reranker cares more about heading_path than tags.
+    tags: list[str] = []
+    t = (title + " " + text[:500]).lower()
+    for kw in ("umzug", "anmeldung", "steuer", "ahv", "iv", "arbeit",
+              "krankenkasse", "familie", "schule", "ausbildung",
+              "migration", "aufenthalt", "einburger", "vignette", "fuhrausweis"):
+        if kw in t:
+            tags.append(kw)
+    return tags
+
+
+def run(limit: int, depth: int, dry_run: bool) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    logger.info("Expanding topic seeds via mega-menu clicks…")
+    leaves = _expand_seeds(SEEDS)
+    logger.info("Discovered %d leaf URLs from %d topics.", len(leaves), len(SEEDS))
+
+    cfg = CrawlConfig(
+        seeds=SEEDS + leaves,
+        url_prefix=URL_PREFIX,
+        max_pages=limit,
+        max_depth=depth,
+        render=True,
+        link_filter=_link_ok,
+    )
+
+    logger.info("Crawl starting — max_pages=%d depth=%d", limit, depth)
+    with Fetcher(rate_limit_seconds=1.5, timeout=20) as fetcher:
+        results = crawl(fetcher, cfg)
+    logger.info("Crawl done. %d pages fetched.", len(results))
+
+    if dry_run:
+        for r in results:
+            logger.info("  %s", r.final_url)
+        return 0
+
+    # Group by category and write per category.
+    by_cat: dict[str, list] = {}
+    for r in results:
+        cat = _category_for(r.final_url or r.url)
+        if cat is None:
+            logger.info("no category for url=%s — skipped", r.url)
+            continue
+        by_cat.setdefault(cat, []).append(r)
+
+    grand = {"docs_written": 0, "total_chunks": 0, "procedures": 0, "articles": 0}
+    for cat, res_list in by_cat.items():
+        summary = make_and_write(
+            category=cat,
+            source_slug=SOURCE_SLUG,
+            source_name=SOURCE_NAME,
+            authority=AUTHORITY,
+            language=LANGUAGE,
+            results=res_list,
+            subcategory_for=_subcategory_for,
+            tags_for=_tags_for,
+            ttl_days=TTL_DAYS,
+        )
+        logger.info("category=%s  %s", cat, summary)
+        for k, v in summary.items():
+            grand[k] = grand[k] + v
+
+    logger.info("Total: %s", grand)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Ingest ch.ch into Phase 1 .jsonl")
+    parser.add_argument("--limit", type=int, default=100, help="Max pages to crawl")
+    parser.add_argument("--depth", type=int, default=3, help="Max crawl depth")
+    parser.add_argument("--dry-run", action="store_true", help="List URLs only")
+    args = parser.parse_args()
+    return run(limit=args.limit, depth=args.depth, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Ships the first Phase 1 ingester: **ch.ch** (federal citizen portal, German only this pass).
- Cracks ch.ch's JS-only URL discovery by clicking mega-menu buttons to enumerate sub-categories.
- Two pipeline fixes surfaced by the first real run: paragraph dedup (ch.ch renders desktop + mobile copies in one DOM) and persistent Chromium (40 min → 6 min).

## Commits
1. `kb: wire Playwright fallback into Fetcher`
2. `kb: shared ingest helpers in scripts/ingest/_base.py`
3. `kb: fix HF tokenizer kwarg (token, not auth_token)` — plus gitignore `data/chunks/` (build artifact)
4. `kb: persistent Chromium + default UA in fetch_rendered` — reuse one browser; drop bot UA that ch.ch 404s
5. `kb: dedupe paragraphs in HTML extractor` — ~26% duplication → 0%
6. `kb: first ingester — ch.ch federal citizen portal`

## Results of a real ingest run

| Metric | Value |
|---|---|
| Docs written | 55 |
| Chunks | 122 |
| Avg tokens/chunk | 146 |
| Paragraph duplication | 0% |
| Runtime | ~6 min |
| Categories filled | admin (33), mobility (8), health (8), housing (6) |

Education + civic got 0 docs because their topic landing pages lack prose; follow-up.

## Test plan
- [x] pytest tests/kb passes (20/20)
- [x] End-to-end run against live ch.ch: 55 docs × 122 chunks written
- [x] Spot-checked chunks: heading_path, subcategory, embed_text prefix all correct
- [ ] Education + civic coverage (follow-up)
- [ ] Dropping sub-50-token chunks (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)