### PR TITLE
kb: Wikipedia + federal law PDF ingesters

### DIFF
--- a/scripts/ingest/law_pdfs.py
+++ b/scripts/ingest/law_pdfs.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Federal law PDF ingester — Phase 1 schema.
+
+Reads hand-downloaded Fedlex PDFs (Bundesverfassung, OR, ZGB, StGB,
+StPO, ZPO, VRV, VTS) and emits one chunk per article (spec §5.3:
+statute -> one article = one chunk, split on Absatz if >2000 tokens).
+
+PDFs live in ``data/law_pdfs/`` (gitignored). Filenames are matched
+against ``LAW_METADATA`` for SR number, abbreviation, and canonical
+law name.
+
+Usage:
+    python -m scripts.ingest.law_pdfs --dry-run
+    python -m scripts.ingest.law_pdfs --pdf-dir /path/to/pdfs
+    python -m scripts.ingest.law_pdfs --limit 1     # one PDF smoke test
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+from backend.kb.chunker import Document, chunk_document
+from backend.kb.metadata import Chunk
+from backend.kb.writers import write_chunks
+from scripts.ingest._base import CHUNKS_ROOT, PROJECT_ROOT
+
+logger = logging.getLogger("zuribot.kb.ingest.law_pdfs")
+
+SOURCE_SLUG = "fedlex"
+AUTHORITY = "federal"
+CATEGORY = "law"
+DOC_TYPE = "statute"
+LANGUAGE = "de"
+LICENSE = "public-domain"  # federal law is public domain in CH
+TTL_DAYS = 365
+
+DEFAULT_PDF_DIR = PROJECT_ROOT / "data" / "law_pdfs"
+
+# Map normalised filename stem → law metadata + fedlex URL.
+# The normaliser lowercases and replaces spaces/dashes with underscores,
+# then picks the first matching prefix.
+LAW_METADATA: dict[str, dict[str, str]] = {
+    "bundesverfassung": {
+        "name": "Bundesverfassung der Schweizerischen Eidgenossenschaft",
+        "abbrev": "BV",
+        "sr": "101",
+        "url": "https://www.fedlex.admin.ch/eli/cc/1999/404/de",
+    },
+    "obligationenrecht": {
+        "name": "Schweizerisches Obligationenrecht",
+        "abbrev": "OR",
+        "sr": "220",
+        "url": "https://www.fedlex.admin.ch/eli/cc/27/317_321_377/de",
+    },
+    "zivilgesetzbuch": {
+        "name": "Schweizerisches Zivilgesetzbuch",
+        "abbrev": "ZGB",
+        "sr": "210",
+        "url": "https://www.fedlex.admin.ch/eli/cc/24/233_245_233/de",
+    },
+    "strafgesetzbuch": {
+        "name": "Schweizerisches Strafgesetzbuch",
+        "abbrev": "StGB",
+        "sr": "311.0",
+        "url": "https://www.fedlex.admin.ch/eli/cc/54/757_781_799/de",
+    },
+    "strafprozessordnung": {
+        "name": "Schweizerische Strafprozessordnung",
+        "abbrev": "StPO",
+        "sr": "312.0",
+        "url": "https://www.fedlex.admin.ch/eli/cc/2010/267/de",
+    },
+    "zivilprozessordnung": {
+        "name": "Schweizerische Zivilprozessordnung",
+        "abbrev": "ZPO",
+        "sr": "272",
+        "url": "https://www.fedlex.admin.ch/eli/cc/2010/262/de",
+    },
+    "verkehrsregelnverordnung": {
+        "name": "Verkehrsregelnverordnung",
+        "abbrev": "VRV",
+        "sr": "741.11",
+        "url": "https://www.fedlex.admin.ch/eli/cc/1963/741_763_779/de",
+    },
+    "verordnung_ueber_die_technischen_anforderungen_an_strassenfahrzeuge": {
+        "name": "Verordnung über die technischen Anforderungen an Strassenfahrzeuge",
+        "abbrev": "VTS",
+        "sr": "741.41",
+        "url": "https://www.fedlex.admin.ch/eli/cc/1995/4425_4425_4425/de",
+    },
+}
+
+
+def _normalise_stem(filename: str) -> str:
+    stem = Path(filename).stem.lower()
+    stem = stem.replace("ä", "ae").replace("ö", "oe").replace("ü", "ue").replace("ß", "ss")
+    stem = re.sub(r"[\s\-]+", "_", stem)
+    stem = re.sub(r"[^a-z0-9_]", "", stem)
+    return stem
+
+
+def _match_metadata(filename: str) -> Optional[dict[str, str]]:
+    stem = _normalise_stem(filename)
+    # Prefer exact prefix match on the longest key so e.g.
+    # "verordnung_ueber_die_technischen_..." wins over "verordnung".
+    for key in sorted(LAW_METADATA, key=len, reverse=True):
+        if stem.startswith(key):
+            return LAW_METADATA[key]
+    return None
+
+
+# ── PDF text extraction ────────────────────────────────────────────────────
+
+def _extract_pdf_text(pdf_path: Path) -> str:
+    from pypdf import PdfReader
+
+    reader = PdfReader(str(pdf_path))
+    parts: list[str] = []
+    for i, page in enumerate(reader.pages):
+        try:
+            text = page.extract_text() or ""
+        except Exception as e:
+            logger.warning("page %d extraction failed in %s: %s", i + 1, pdf_path.name, e)
+            continue
+        # Join hyphenated line-break words.
+        text = re.sub(r"-\n(\w)", r"\1", text)
+        # Collapse mid-sentence line breaks to spaces.
+        text = re.sub(r"(\S)\n(\S)", r"\1 \2", text)
+        text = re.sub(r"\n{3,}", "\n\n", text).strip()
+        if text and not _is_index_page(text):
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _is_index_page(text: str) -> bool:
+    """Heuristic: TOC / footnote pages have short lines and many refs."""
+    lines = [l.strip() for l in text.split("\n") if l.strip()]
+    if len(lines) < 4:
+        return False
+    short = sum(1 for l in lines if len(l.split()) < 6)
+    refs = sum(1 for l in lines if re.match(r"^(Art\.|§|\d+\.?\s|AS \d|SR \d|BBl )", l))
+    return (short / len(lines) > 0.70) and (refs / len(lines) > 0.40)
+
+
+# ── Article splitting ──────────────────────────────────────────────────────
+
+# Match "Art. 12", "Art. 12a", "Artikel 5" at the start of a line.
+_ARTICLE_RE = re.compile(
+    r"^\s*(?:Art\.|Artikel)\s+(\d+[a-z]?(?:bis|ter|quater|quinquies|sexies)?)\b",
+    re.MULTILINE,
+)
+
+
+def _split_articles(text: str) -> list[tuple[str, str]]:
+    """Return list of (article_number, article_text). Text before the first
+    article (title page, preamble) is bundled into a synthetic 'preamble'."""
+    matches = list(_ARTICLE_RE.finditer(text))
+    if not matches:
+        return [("preamble", text.strip())]
+
+    out: list[tuple[str, str]] = []
+    first_start = matches[0].start()
+    if first_start > 0:
+        preamble = text[:first_start].strip()
+        if len(preamble) > 200:
+            out.append(("preamble", preamble))
+
+    for i, m in enumerate(matches):
+        art_no = m.group(1)
+        body_start = m.start()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[body_start:body_end].strip()
+        if body:
+            out.append((art_no, body))
+    return out
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+def _ingest_one(pdf_path: Path, dry_run: bool) -> dict:
+    meta = _match_metadata(pdf_path.name)
+    if not meta:
+        logger.warning("no metadata match for %s — skipping", pdf_path.name)
+        return {"docs_written": 0, "total_chunks": 0, "skipped": 1}
+
+    logger.info("Processing %s (%s, SR %s)", pdf_path.name, meta["abbrev"], meta["sr"])
+
+    text = _extract_pdf_text(pdf_path)
+    if not text:
+        logger.warning("no text extracted from %s", pdf_path.name)
+        return {"docs_written": 0, "total_chunks": 0, "skipped": 1}
+
+    articles = _split_articles(text)
+    logger.info("  %d articles detected, %d chars", len(articles), len(text))
+
+    if dry_run:
+        return {"docs_written": 0, "total_chunks": 0, "skipped": 0}
+
+    today = date.today()
+    docs_written = 0
+    total_chunks = 0
+
+    for art_no, body in articles:
+        doc_title = f"{meta['abbrev']} Art. {art_no}" if art_no != "preamble" else f"{meta['abbrev']} — Präambel"
+        # Per-article fragment keeps doc_id unique (make_doc_id hashes source_url).
+        frag = "preamble" if art_no == "preamble" else f"art-{art_no}"
+        doc = Document(
+            source_url=f"{meta['url']}#{frag}",
+            source_name=f"Fedlex — {meta['abbrev']}",
+            title=doc_title,
+            language=LANGUAGE,
+            category=CATEGORY,  # type: ignore[arg-type]
+            authority=AUTHORITY,  # type: ignore[arg-type]
+            doc_type=DOC_TYPE,  # type: ignore[arg-type]
+            text=body,
+            subcategory=None,
+            tags=[meta["abbrev"].lower()],
+            created_at=today,
+            updated_at=today,
+            ttl_days=TTL_DAYS,
+            license=LICENSE,
+            law_name=meta["name"],
+            abbrev=meta["abbrev"],
+            sr_number=meta["sr"],
+            article_number=None if art_no == "preamble" else art_no,
+        )
+        try:
+            chunks: list[Chunk] = chunk_document(doc)
+        except Exception as e:
+            logger.warning("chunk failed %s Art. %s: %s", meta["abbrev"], art_no, e)
+            continue
+
+        write_chunks(chunks, CHUNKS_ROOT, CATEGORY, SOURCE_SLUG)
+        docs_written += 1
+        total_chunks += len(chunks)
+
+    logger.info("  wrote %d docs / %d chunks", docs_written, total_chunks)
+    return {"docs_written": docs_written, "total_chunks": total_chunks, "skipped": 0}
+
+
+def run(pdf_dir: Path, limit: int, dry_run: bool) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if not pdf_dir.exists():
+        logger.error("PDF dir not found: %s", pdf_dir)
+        return 1
+
+    pdfs = sorted(pdf_dir.glob("*.pdf"))
+    if limit:
+        pdfs = pdfs[:limit]
+    if not pdfs:
+        logger.error("no PDFs in %s", pdf_dir)
+        return 1
+
+    logger.info("Found %d PDFs in %s", len(pdfs), pdf_dir)
+
+    grand = {"docs_written": 0, "total_chunks": 0, "skipped": 0}
+    for pdf in pdfs:
+        stats = _ingest_one(pdf, dry_run)
+        for k in grand:
+            grand[k] += stats[k]
+
+    logger.info("Total: %s", grand)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Ingest federal law PDFs")
+    parser.add_argument("--pdf-dir", type=Path, default=DEFAULT_PDF_DIR,
+                        help=f"Directory containing PDFs (default: {DEFAULT_PDF_DIR})")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Process only first N PDFs (0 = all)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show matches, don't write chunks")
+    args = parser.parse_args()
+    return run(pdf_dir=args.pdf_dir, limit=args.limit, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest/wikipedia.py
+++ b/scripts/ingest/wikipedia.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Wikipedia ingester — curated Zürich list.
+
+Fills three gaps in one shot: ``neighborhoods`` (Kreise + Quartiere),
+``leisure`` with ``historical`` doc_type (landmarks, festivals — the
+character-shaping layer per spec §1 and memory), and EN coverage for
+expats (audit flagged <0.2% of old KB).
+
+Content comes from Wikipedia's REST API (`/page/html/{title}`) —
+clean Parsoid HTML, no scraping. We strip Wikipedia's structural
+noise (infoboxes, references, see-also, coordinates, edit-section
+links) and feed the rest to the shared heading/paragraph extractor
+in ``_base.py``.
+
+Article list is hand-picked. We deliberately do not crawl — the spec
+says curate Wikipedia for quality, not bulk.
+
+Usage:
+    python -m scripts.ingest.wikipedia --dry-run
+    python -m scripts.ingest.wikipedia --limit 5
+    python -m scripts.ingest.wikipedia                # full curated run
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from datetime import date
+from pathlib import Path
+from typing import Optional
+from urllib.parse import quote
+
+import requests
+from bs4 import BeautifulSoup
+
+from backend.kb.chunker import Document, chunk_document
+from backend.kb.metadata import Chunk
+from backend.kb.writers import write_chunks
+from scripts.ingest._base import CHUNKS_ROOT, extract_title_and_sections
+
+logger = logging.getLogger("zuribot.kb.ingest.wikipedia")
+
+SOURCE_SLUG = "wikipedia"
+AUTHORITY = "wikipedia"
+TTL_DAYS = 365
+LICENSE = "CC-BY-SA"
+USER_AGENT = (
+    "BuenzliBot/0.1 (https://buenzli.space/bot; knowledge base ingestion)"
+)
+
+# (title, category, doc_type, language, optional district)
+# doc_type="historical" triggers smaller (300-400 token) chunking per spec §5.3
+CURATED: list[tuple[str, str, str, str, Optional[str]]] = [
+    # neighborhoods — Kreise + notable Quartiere
+    ("Zürich", "neighborhoods", "article", "de", None),
+    ("Kreis 1 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 1"),
+    ("Kreis 2 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 2"),
+    ("Kreis 3 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 3"),
+    ("Kreis 4 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 4"),
+    ("Kreis 5 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 5"),
+    ("Kreis 6 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 6"),
+    ("Kreis 7 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 7"),
+    ("Kreis 8 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 8"),
+    ("Kreis 9 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 9"),
+    ("Kreis 10 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 10"),
+    ("Kreis 11 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 11"),
+    ("Kreis 12 (Stadt Zürich)", "neighborhoods", "article", "de", "Kreis 12"),
+    ("Langstrasse", "neighborhoods", "article", "de", "Kreis 4"),
+    ("Seefeld (Zürich)", "neighborhoods", "article", "de", "Kreis 8"),
+    ("Zürich-West", "neighborhoods", "article", "de", "Kreis 5"),
+    ("Wiedikon", "neighborhoods", "article", "de", "Kreis 3"),
+    ("Wipkingen", "neighborhoods", "article", "de", "Kreis 10"),
+    ("Oerlikon", "neighborhoods", "article", "de", "Kreis 11"),
+    ("Altstetten", "neighborhoods", "article", "de", "Kreis 9"),
+
+    # leisure/historical — landmarks, geography (character-shaping)
+    ("Zürichsee", "leisure", "historical", "de", None),
+    ("Limmat", "leisure", "historical", "de", None),
+    ("Uetliberg", "leisure", "historical", "de", None),
+    ("Zürichberg", "leisure", "historical", "de", None),
+    ("Grossmünster", "leisure", "historical", "de", "Kreis 1"),
+    ("Fraumünster", "leisure", "historical", "de", "Kreis 1"),
+    ("Hauptbahnhof Zürich", "leisure", "historical", "de", "Kreis 1"),
+    ("Bahnhofstrasse (Zürich)", "leisure", "historical", "de", "Kreis 1"),
+    ("Kunsthaus Zürich", "leisure", "historical", "de", "Kreis 1"),
+    ("Opernhaus Zürich", "leisure", "historical", "de", "Kreis 1"),
+    ("Schauspielhaus Zürich", "leisure", "historical", "de", None),
+    ("Schweizerisches Nationalmuseum", "leisure", "historical", "de", "Kreis 1"),
+    ("Zoo Zürich", "leisure", "historical", "de", "Kreis 7"),
+    ("Tonhalle Zürich", "leisure", "historical", "de", "Kreis 2"),
+    ("Geschichte der Stadt Zürich", "leisure", "historical", "de", None),
+
+    # leisure — festivals (article, not historical — they're recurring)
+    ("Street Parade", "leisure", "article", "de", None),
+    ("Sechseläuten", "leisure", "article", "de", None),
+    ("Züri Fäscht", "leisure", "article", "de", None),
+    ("Zurich Film Festival", "leisure", "article", "de", None),
+
+    # education — major universities
+    ("Universität Zürich", "education", "article", "de", None),
+    ("ETH Zürich", "education", "article", "de", None),
+
+    # mobility — backbone operators
+    ("Verkehrsbetriebe Zürich", "mobility", "article", "de", None),
+    ("S-Bahn Zürich", "mobility", "article", "de", None),
+
+    # civic — canton background
+    ("Kanton Zürich", "civic", "article", "de", None),
+
+    # EN coverage — small but strategic
+    ("Zürich", "neighborhoods", "article", "en", None),
+    ("Swiss German", "civic", "article", "en", None),
+    ("History of Zürich", "leisure", "historical", "en", None),
+    ("Old Swiss Confederacy", "leisure", "historical", "en", None),
+]
+
+
+# Sections on WP pages whose headings indicate ignorable tails.
+_STRIP_HEADINGS = {
+    "einzelnachweise", "literatur", "weblinks", "siehe auch",
+    "references", "external links", "see also", "bibliography",
+    "notes", "further reading", "sources", "fussnoten",
+}
+
+
+def _wp_url(title: str, lang: str) -> str:
+    return f"https://{lang}.wikipedia.org/wiki/{quote(title.replace(' ', '_'))}"
+
+
+def _fetch_html(title: str, lang: str, timeout: int = 30) -> Optional[str]:
+    """Fetch Parsoid HTML for ``title`` from ``{lang}.wikipedia.org``."""
+    api = f"https://{lang}.wikipedia.org/api/rest_v1/page/html/{quote(title.replace(' ', '_'))}"
+    try:
+        resp = requests.get(api, timeout=timeout, headers={"User-Agent": USER_AGENT})
+    except requests.RequestException as e:
+        logger.warning("fetch failed [%s] %s: %s", lang, title, e)
+        return None
+    if resp.status_code == 404:
+        logger.info("not found [%s] %s", lang, title)
+        return None
+    if resp.status_code != 200:
+        logger.warning("HTTP %s [%s] %s", resp.status_code, lang, title)
+        return None
+    return resp.text
+
+
+def _clean_wikipedia_html(html: str, title: str) -> bytes:
+    """Remove Wikipedia-specific noise before handing to the shared extractor.
+
+    Drops infoboxes, references, coordinates, tables of contents, hatnotes,
+    edit-links, and sections after "References"/"See also"/"Literatur"/etc.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Drop obvious noise by class/selector.
+    noise_selectors = [
+        ".infobox", ".navbox", ".sidebar", ".reference", ".mw-editsection",
+        ".reflist", "ol.references", ".thumb", ".gallery", ".hatnote",
+        ".shortdescription", ".coordinates", ".mw-empty-elt", ".metadata",
+        ".mw-cite-backlink", "table.wikitable", "sup.reference",
+        ".vertical-navbox", ".portal", ".catlinks", "#toc",
+        "figure", "style", "script",
+    ]
+    for sel in noise_selectors:
+        for el in soup.select(sel):
+            el.decompose()
+
+    # Strip everything from a "References"-class heading onwards.
+    for h in soup.find_all(["h1", "h2", "h3"]):
+        label = h.get_text(" ", strip=True).lower().strip()
+        if label in _STRIP_HEADINGS:
+            # Remove this heading and all following siblings.
+            nxt = h.find_next_sibling()
+            h.decompose()
+            while nxt is not None:
+                sib = nxt.find_next_sibling()
+                nxt.decompose()
+                nxt = sib
+            break
+
+    # Wikipedia Parsoid output usually has <section> per h2; make sure the page
+    # has an <h1> with the article title so the extractor picks it up.
+    if soup.body and not soup.find("h1"):
+        h1 = soup.new_tag("h1")
+        h1.string = title
+        soup.body.insert(0, h1)
+
+    return str(soup).encode("utf-8")
+
+
+def run(limit: int, dry_run: bool) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    items = CURATED[:limit] if limit else CURATED
+    logger.info("Processing %d articles (of %d curated).", len(items), len(CURATED))
+
+    if dry_run:
+        by_cat: dict[str, int] = {}
+        for _, cat, *_ in items:
+            by_cat[cat] = by_cat.get(cat, 0) + 1
+        for cat, n in sorted(by_cat.items(), key=lambda x: -x[1]):
+            logger.info("  %-14s %3d", cat, n)
+        return 0
+
+    today = date.today()
+    grand = {"docs_written": 0, "total_chunks": 0, "skipped": 0}
+
+    for title, category, doc_type, lang, district in items:
+        src_url = _wp_url(title, lang)
+        html = _fetch_html(title, lang)
+        if html is None:
+            grand["skipped"] += 1
+            continue
+        cleaned = _clean_wikipedia_html(html, title)
+
+        page_title, sections, full_text = extract_title_and_sections(cleaned)
+        if not page_title:
+            page_title = title
+        if len(full_text) < 400:
+            logger.info("skip (too short) %s", src_url)
+            grand["skipped"] += 1
+            continue
+
+        doc = Document(
+            source_url=src_url,
+            source_name=f"Wikipedia ({lang.upper()})",
+            title=page_title,
+            language=lang,
+            category=category,  # type: ignore[arg-type]
+            authority=AUTHORITY,  # type: ignore[arg-type]
+            doc_type=doc_type,  # type: ignore[arg-type]
+            sections=sections,
+            subcategory=None,
+            tags=[],
+            created_at=today,
+            updated_at=today,
+            ttl_days=TTL_DAYS,
+            district=district,
+            license=LICENSE,
+        )
+        try:
+            chunks: list[Chunk] = chunk_document(doc)
+        except Exception as e:
+            logger.warning("chunk failed %s: %s", src_url, e)
+            grand["skipped"] += 1
+            continue
+
+        write_chunks(chunks, CHUNKS_ROOT, category, SOURCE_SLUG)
+        grand["docs_written"] += 1
+        grand["total_chunks"] += len(chunks)
+        logger.info("  [%s/%s] %s → %d chunks", lang, category, title, len(chunks))
+
+        time.sleep(0.4)  # polite
+
+    logger.info("Total: %s", grand)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Ingest curated Wikipedia articles")
+    parser.add_argument("--limit", type=int, default=0,
+                        help="Cap number of articles (0 = full list)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print category breakdown, don't fetch")
+    args = parser.parse_args()
+    return run(limit=args.limit, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Wikipedia ingester: 48 curated DE+EN articles (Kreise, Quartiere, landmarks, festivals, unis, transport). Parsoid HTML + noise stripping; historical doc_type for character-shaping landmarks per spec §5.3.
- Federal law PDF ingester: 8 Fedlex laws split per-article (BV, OR, ZGB, StGB, StPO, ZPO, VRV, VTS). One article = one chunk, Absatz-split if huge.

## Test plan
- [x] Wikipedia --limit 5 → 159 chunks, Kreise titles resolved via WP redirect
- [x] Law PDFs --limit 1 (Bundesverfassung) → 202 articles, 421 chunks, clean per-article heading_path
- [ ] Full runs deferred to Phase 2 (AI pod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)