### PR TITLE
kb: Phase 1 ingester fixes — chunker, law_pdfs, zh_cantonal_law, zuerich_com, emergency, gaultmillau, drop phzh

### DIFF
--- a/backend/kb/chunker.py
+++ b/backend/kb/chunker.py
@@ -51,6 +51,12 @@ STATUTE_ABSATZ_SPLIT = 2000
 HISTORICAL_MIN = 300
 HISTORICAL_MAX = 400
 
+# Safety guard: a single section longer than this (in characters) is almost
+# always page noise (boilerplate dumps, JS payload bleed-through, navigation
+# turned into prose). Tokenizing huge inputs is slow and they yield low-value
+# chunks. Truncate with a warning.
+MAX_SECTION_CHARS = 80_000
+
 
 @dataclass
 class Section:
@@ -132,8 +138,12 @@ def _pack_sentences(
         s = sentences[i]
         s_tokens = count_tokens(s)
 
-        # Guard: a single sentence bigger than hard max gets emitted alone.
-        if s_tokens > HARD_MAX:
+        # Guard: a single sentence bigger than target_max gets emitted alone.
+        # (Below target_max means it can combine with neighbours; above means
+        # combining would either overflow target_max or — worse — leave us
+        # in an infinite emit-and-seed loop because the seeded overlap can
+        # never make room for a sentence that's already past target_max.)
+        if s_tokens > target_max:
             if cur:
                 chunks.append(" ".join(cur))
                 cur, cur_tokens = [], 0
@@ -154,6 +164,11 @@ def _pack_sentences(
                     break
                 tail.insert(0, prev)
                 tail_tokens += t
+            # Progress guard: if the seeded tail still leaves no room for s,
+            # drop the tail. s will start the next chunk alone (since
+            # s_tokens <= target_max here, that's safe).
+            if tail_tokens + s_tokens > target_max:
+                tail, tail_tokens = [], 0
             cur = tail
             cur_tokens = tail_tokens
             continue
@@ -263,6 +278,20 @@ def chunk_document(doc: Document) -> list[Chunk]:
         raise ValueError("Document must have either sections or text")
     if doc.created_at is None or doc.updated_at is None:
         raise ValueError("created_at and updated_at are required")
+
+    for sec in doc.sections:
+        if len(sec.text) > MAX_SECTION_CHARS:
+            logger.warning(
+                "truncating oversized section url=%s heading=%r %d->%d chars",
+                doc.source_url, sec.heading, len(sec.text), MAX_SECTION_CHARS,
+            )
+            sec.text = sec.text[:MAX_SECTION_CHARS]
+    if len(doc.text) > MAX_SECTION_CHARS:
+        logger.warning(
+            "truncating oversized doc.text url=%s %d->%d chars",
+            doc.source_url, len(doc.text), MAX_SECTION_CHARS,
+        )
+        doc.text = doc.text[:MAX_SECTION_CHARS]
 
     doc_id = make_doc_id(doc.source_url, doc.language)
 

--- a/scripts/ingest/_base.py
+++ b/scripts/ingest/_base.py
@@ -49,6 +49,23 @@ def extract_title_and_sections(
     full_text is the concatenated body — useful for procedure heuristics.
     """
     soup = BeautifulSoup(html, "html.parser")
+
+    # Pull a title BEFORE stripping nav/header — some sites (zuerich.com)
+    # put the page h1 inside <header>, which would otherwise vanish.
+    title = ""
+    h1 = soup.find("h1")
+    if h1:
+        title = h1.get_text(" ", strip=True)
+    if not title:
+        og = soup.find("meta", property="og:title")
+        if og and og.get("content"):
+            title = og["content"].strip()
+    if not title and soup.title and soup.title.string:
+        # Older / hand-built sites (e.g. some Quartierverein WordPress
+        # themes) don't render an <h1>. Fall back to the document <title>
+        # so we don't drop the page entirely.
+        title = soup.title.string.strip()
+
     # Strip noise tags. We *don't* strip ``form`` here because some legacy
     # sites (some Quartierverein WordPress themes) wrap the entire page —
     # including <main> — in a <form>, so decomposing it nukes the content.
@@ -58,14 +75,6 @@ def extract_title_and_sections(
             continue
         for tag in soup.select(sel):
             tag.decompose()
-
-    h1 = soup.find("h1")
-    title = h1.get_text(" ", strip=True) if h1 else ""
-    if not title and soup.title and soup.title.string:
-        # Older / hand-built sites (e.g. some Quartierverein WordPress
-        # themes) don't render an <h1>. Fall back to the document <title>
-        # so we don't drop the page entirely.
-        title = soup.title.string.strip()
 
     main = soup.select_one(main_selector) or soup.body or soup
     sections: list[Section] = []
@@ -229,6 +238,8 @@ def make_and_write(
             updated_at=today,
             ttl_days=ttl_days,
         )
+        body_chars = sum(len(s.text) for s in sections)
+        logger.info("chunking url=%s sections=%d chars=%d", res.url, len(sections), body_chars)
         try:
             chunks: list[Chunk] = chunk_document(doc)
         except Exception as e:

--- a/scripts/ingest/emergency_refs.py
+++ b/scripts/ingest/emergency_refs.py
@@ -125,7 +125,143 @@ TOX = SiteConfig(
     ],
 )
 
-SITES: dict[str, SiteConfig] = {"tox": TOX}
+DARGEBOTENE_HAND = SiteConfig(
+    slug="dargebotene_hand",
+    source_name="Die Dargebotene Hand 143",
+    authority="community",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.143.ch/",
+            entity_name="Tel 143 — Die Dargebotene Hand",
+            entity_type="Notfall-Hotline",
+            title_override="Tel 143 — Die Dargebotene Hand",
+            subcategory="emergency/seelsorge",
+            tags=["143", "krise", "seelsorge", "notfall"],
+        ),
+        SiteEntry(
+            url="https://www.143.ch/ueber-uns/",
+            entity_name="Tel 143 — Über uns",
+            entity_type="Institution",
+            title_override="Tel 143 — Über uns",
+            subcategory="emergency/seelsorge",
+            tags=["143", "stiftung", "portrait"],
+        ),
+    ],
+)
+
+PRO_JUVENTUTE = SiteConfig(
+    slug="pro_juventute_147",
+    source_name="Pro Juventute 147",
+    authority="community",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.147.ch/",
+            entity_name="Pro Juventute 147 — Beratung für Jugendliche",
+            entity_type="Notfall-Hotline",
+            title_override="Pro Juventute 147 — Beratung für Kinder und Jugendliche",
+            subcategory="emergency/jugendberatung",
+            tags=["147", "jugend", "kinder", "krise", "beratung"],
+        ),
+    ],
+)
+
+REDEN_KANN_RETTEN = SiteConfig(
+    slug="reden_kann_retten",
+    source_name="Reden kann retten — Suizidprävention",
+    authority="community",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.reden-kann-retten.ch/",
+            entity_name="Reden kann retten",
+            entity_type="Notfall-Hotline",
+            title_override="Reden kann retten — Suizidprävention Schweiz",
+            subcategory="emergency/suizidpraevention",
+            tags=["suizid", "praevention", "krise", "143"],
+        ),
+    ],
+)
+
+REGA = SiteConfig(
+    slug="rega",
+    source_name="Schweizerische Rettungsflugwacht Rega",
+    authority="community",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.rega.ch/",
+            entity_name="Rega — Notruf 1414",
+            entity_type="Notfall-Hotline",
+            title_override="Rega — Schweizerische Rettungsflugwacht",
+            subcategory="emergency/luftrettung",
+            tags=["rega", "1414", "luftrettung", "notfall"],
+        ),
+    ],
+)
+
+USZ_NOTFALL = SiteConfig(
+    slug="usz_notfall",
+    source_name="UniversitätsSpital Zürich — Notfallzentrum",
+    authority="cantonal",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.usz.ch/notfall/",
+            entity_name="USZ — Notfallzentrum",
+            entity_type="Notfallstation",
+            title_override="USZ — Notfallzentrum (Erwachsene)",
+            subcategory="emergency/spital_notfall",
+            tags=["usz", "notfall", "spital", "erwachsene"],
+        ),
+    ],
+)
+
+KISPI_NOTFALL = SiteConfig(
+    slug="kispi_notfall",
+    source_name="Kinderspital Zürich — Notfall",
+    authority="cantonal",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.kispi.uzh.ch/notfall",
+            entity_name="Kispi — Notfallstation",
+            entity_type="Notfallstation",
+            title_override="Kinderspital Zürich — Notfall",
+            subcategory="emergency/spital_notfall",
+            tags=["kispi", "kinder", "notfall", "spital"],
+        ),
+    ],
+)
+
+KAPO_ZH = SiteConfig(
+    slug="kapo_zh",
+    source_name="Kantonspolizei Zürich",
+    authority="cantonal",
+    ttl_days=None,
+    entries=[
+        SiteEntry(
+            url="https://www.zh.ch/de/sicherheitsdirektion/kantonspolizei-zuerich.html",
+            entity_name="Kantonspolizei Zürich",
+            entity_type="Polizei",
+            title_override="Kantonspolizei Zürich",
+            subcategory="emergency/polizei",
+            tags=["polizei", "117", "kapo", "kanton"],
+        ),
+    ],
+)
+
+SITES: dict[str, SiteConfig] = {
+    "tox": TOX,
+    "dargebotene_hand": DARGEBOTENE_HAND,
+    "pro_juventute_147": PRO_JUVENTUTE,
+    "reden_kann_retten": REDEN_KANN_RETTEN,
+    "rega": REGA,
+    "usz_notfall": USZ_NOTFALL,
+    "kispi_notfall": KISPI_NOTFALL,
+    "kapo_zh": KAPO_ZH,
+}
 
 
 # Extraction ───────────────────────────────────────────────────────────────
@@ -278,7 +414,8 @@ def main() -> int:
                         help="Cap entries per site (0 = no cap)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print planned URLs; don't fetch")
-    parser.add_argument("--site", choices=("tox", "all"), default="all",
+    parser.add_argument("--site", choices=tuple(SITES.keys()) + ("all",),
+                        default="all",
                         help="Which site to ingest (default: all)")
     args = parser.parse_args()
     return run(limit=args.limit, dry_run=args.dry_run, site=args.site)

--- a/scripts/ingest/food_drink_refs.py
+++ b/scripts/ingest/food_drink_refs.py
@@ -59,6 +59,9 @@ class SiteEntry:
     title_override: Optional[str] = None
     subcategory: Optional[str] = None
     tags: list[str] = None  # type: ignore[assignment]
+    # Some discovery functions fetch the page to filter (e.g. by PLZ).
+    # When set, the main loop reuses these bytes instead of re-fetching.
+    prefetched_html: Optional[bytes] = None
 
 
 @dataclass
@@ -74,54 +77,147 @@ class SiteConfig:
     doc_type: str = "reference"
 
 
+_GAULTMILLAU_META = [
+    SiteEntry(
+        url="https://www.gaultmillau.ch/",
+        entity_name="Gault Millau Schweiz",
+        entity_type="Restaurantführer",
+        title_override="Gault Millau Schweiz — Übersicht",
+        subcategory="food_drink/guides",
+        tags=["gaultmillau", "restaurantfuehrer", "gastronomie"],
+    ),
+    SiteEntry(
+        url="https://www.gaultmillau.ch/restaurants",
+        entity_name="Gault Millau — Restaurants",
+        entity_type="Restaurantführer",
+        title_override="Gault Millau — Restaurants (Bewertungssystem)",
+        subcategory="food_drink/guides",
+        tags=["gaultmillau", "restaurants", "punkte", "bewertung"],
+    ),
+    SiteEntry(
+        url="https://www.gaultmillau.ch/zueri-isst",
+        entity_name="Gault Millau — Züri isst",
+        entity_type="Restaurantführer",
+        title_override="Gault Millau — Züri isst (Zürich-Sektion)",
+        subcategory="food_drink/guides",
+        tags=["gaultmillau", "zueri", "zuerich", "restaurants"],
+    ),
+    SiteEntry(
+        url="https://www.gaultmillau.ch/hot-ten",
+        entity_name="Gault Millau — Hot Ten",
+        entity_type="Restaurantführer",
+        title_override="Gault Millau — Hot Ten Listen",
+        subcategory="food_drink/guides",
+        tags=["gaultmillau", "hot-ten", "listen"],
+    ),
+    SiteEntry(
+        url="https://www.gaultmillau.ch/unsere-redaktion",
+        entity_name="Gault Millau — Redaktion",
+        entity_type="Restaurantführer",
+        title_override="Gault Millau — Unsere Redaktion",
+        subcategory="food_drink/guides",
+        tags=["gaultmillau", "redaktion", "ueberuns"],
+    ),
+]
+
+
+_PLZ_ZH_RE = __import__("re").compile(r"\b8\d{3}\b")
+
+
+def _discover_gaultmillau_zurich(fetcher: Fetcher, max_pages: int) -> list[SiteEntry]:
+    """Walk gaultmillau.ch sitemap, fetch each restaurant detail page,
+    keep only those with a Zürich-canton PLZ (8000-8999) in the body.
+
+    The sitemap index lists ~100 monthly sub-sitemaps; together they
+    contain ~860 unique restaurant detail URLs across all of Switzerland.
+    Detail pages return clean review prose via plain HTTP — no Playwright
+    needed. Filtering by PLZ inline avoids over-ingesting French-CH or
+    Tessin restaurants while staying simple.
+
+    ``max_pages`` caps the number of detail-page candidates probed (0 = no cap).
+    """
+    import re
+    from urllib.parse import urljoin
+
+    INDEX = "https://www.gaultmillau.ch/sitemap.xml"
+    LOC_RE = re.compile(r"<loc>([^<]+)</loc>")
+    DETAIL_RE = re.compile(r"/restaurants/[^/]+-\d+/?$")
+
+    res = fetcher.fetch(INDEX)
+    if res is None or res.status_code != 200:
+        logger.warning("[gaultmillau] sitemap index fetch failed")
+        return []
+    sub_sitemaps = LOC_RE.findall(res.content.decode("utf-8", "ignore"))
+    logger.info("[gaultmillau] sitemap index: %d sub-sitemaps", len(sub_sitemaps))
+
+    detail_urls: list[str] = []
+    seen: set[str] = set()
+    for sm in sub_sitemaps:
+        rr = fetcher.fetch(sm)
+        if rr is None or rr.status_code != 200:
+            continue
+        for u in LOC_RE.findall(rr.content.decode("utf-8", "ignore")):
+            u = u.rstrip("/")
+            if DETAIL_RE.search(u + "/") and u not in seen:
+                seen.add(u)
+                detail_urls.append(u)
+    logger.info("[gaultmillau] %d candidate restaurant URLs across sitemaps",
+                len(detail_urls))
+
+    if max_pages and max_pages > 0:
+        detail_urls = detail_urls[:max_pages]
+
+    out: list[SiteEntry] = []
+    for i, url in enumerate(detail_urls, 1):
+        rr = fetcher.fetch(url)
+        if rr is None or rr.status_code != 200:
+            continue
+        soup = BeautifulSoup(rr.content, "html.parser")
+        for sel in ("script", "style", "nav", "header", "footer", "aside"):
+            for tag in soup.select(sel):
+                tag.decompose()
+        main = soup.select_one("main") or soup.body or soup
+        text_head = main.get_text("\n", strip=True)[:1000] if main else ""
+
+        # PLZ filter — Zürich canton is 8000-8999. Extra-canton PLZs
+        # starting with 8 (e.g. 8580 Amriswil TG) exist but are rare;
+        # the false-positive rate is low enough to not bother with a
+        # canton list.
+        if not _PLZ_ZH_RE.search(text_head):
+            if i % 50 == 0:
+                logger.info("[gaultmillau] %d/%d probed, %d ZH so far",
+                            i, len(detail_urls), len(out))
+            continue
+
+        h1 = soup.find("h1")
+        name = h1.get_text(" ", strip=True) if h1 else url.rsplit("/", 1)[-1]
+        slug = url.rsplit("/", 1)[-1]
+        out.append(SiteEntry(
+            url=url,
+            entity_name=name,
+            entity_type="Restaurant",
+            title_override=f"Gault Millau — {name}",
+            subcategory="food_drink/restaurants",
+            tags=["gaultmillau", "restaurant", "zuerich", "review"],
+            prefetched_html=rr.content,
+        ))
+        if i % 50 == 0:
+            logger.info("[gaultmillau] %d/%d probed, %d ZH so far",
+                        i, len(detail_urls), len(out))
+    logger.info("[gaultmillau] kept %d Zürich-canton restaurants out of %d",
+                len(out), len(detail_urls))
+    return out
+
+
 GAULTMILLAU = SiteConfig(
     slug="gaultmillau",
     source_name="Gault Millau Schweiz",
     authority="community",
     ttl_days=180,
-    entries=[
-        SiteEntry(
-            url="https://www.gaultmillau.ch/",
-            entity_name="Gault Millau Schweiz",
-            entity_type="Restaurantführer",
-            title_override="Gault Millau Schweiz — Übersicht",
-            subcategory="food_drink/guides",
-            tags=["gaultmillau", "restaurantfuehrer", "gastronomie"],
-        ),
-        SiteEntry(
-            url="https://www.gaultmillau.ch/restaurants",
-            entity_name="Gault Millau — Restaurants",
-            entity_type="Restaurantführer",
-            title_override="Gault Millau — Restaurants (Bewertungssystem)",
-            subcategory="food_drink/guides",
-            tags=["gaultmillau", "restaurants", "punkte", "bewertung"],
-        ),
-        SiteEntry(
-            url="https://www.gaultmillau.ch/zueri-isst",
-            entity_name="Gault Millau — Züri isst",
-            entity_type="Restaurantführer",
-            title_override="Gault Millau — Züri isst (Zürich-Sektion)",
-            subcategory="food_drink/guides",
-            tags=["gaultmillau", "zueri", "zuerich", "restaurants"],
-        ),
-        SiteEntry(
-            url="https://www.gaultmillau.ch/hot-ten",
-            entity_name="Gault Millau — Hot Ten",
-            entity_type="Restaurantführer",
-            title_override="Gault Millau — Hot Ten Listen",
-            subcategory="food_drink/guides",
-            tags=["gaultmillau", "hot-ten", "listen"],
-        ),
-        SiteEntry(
-            url="https://www.gaultmillau.ch/unsere-redaktion",
-            entity_name="Gault Millau — Redaktion",
-            entity_type="Restaurantführer",
-            title_override="Gault Millau — Unsere Redaktion",
-            subcategory="food_drink/guides",
-            tags=["gaultmillau", "redaktion", "ueberuns"],
-        ),
-    ],
+    entries=_GAULTMILLAU_META,
+    discover=_discover_gaultmillau_zurich,
 )
+
 
 def _discover_harrysding(fetcher: Fetcher, max_pages: int) -> list[SiteEntry]:
     """Walk harrysding.ch /category/restaurants-zuerich/page/N until empty.
@@ -225,13 +321,13 @@ def _ingest_site(site: SiteConfig, limit: int, dry_run: bool) -> dict:
     skipped = 0
 
     with Fetcher(rate_limit_seconds=1.0, timeout=25) as fetcher:
+        entries = list(site.entries)
         if site.discover is not None:
-            max_pages = limit if limit else 40
-            entries = site.discover(fetcher, max_pages)  # type: ignore[misc]
-        else:
-            entries = site.entries
-            if limit:
-                entries = entries[:limit]
+            max_pages = limit if limit else 0
+            discovered = site.discover(fetcher, max_pages)  # type: ignore[misc]
+            entries = entries + discovered
+        elif limit:
+            entries = entries[:limit]
 
         if dry_run:
             for e in entries:
@@ -241,7 +337,8 @@ def _ingest_site(site: SiteConfig, limit: int, dry_run: bool) -> dict:
                     "site": site.slug, "planned": len(entries)}
 
         for entry in entries:
-            html = _fetch_with_fallback(fetcher, entry.url)
+            html = entry.prefetched_html if entry.prefetched_html is not None \
+                else _fetch_with_fallback(fetcher, entry.url)
             if html is None:
                 logger.warning("fetch failed url=%s", entry.url)
                 skipped += 1

--- a/scripts/ingest/law_pdfs.py
+++ b/scripts/ingest/law_pdfs.py
@@ -98,7 +98,8 @@ LAW_METADATA: dict[str, dict[str, str]] = {
 
 
 def _normalise_stem(filename: str) -> str:
-    stem = Path(filename).stem.lower()
+    import unicodedata
+    stem = unicodedata.normalize("NFC", Path(filename).stem).lower()
     stem = stem.replace("ä", "ae").replace("ö", "oe").replace("ü", "ue").replace("ß", "ss")
     stem = re.sub(r"[\s\-]+", "_", stem)
     stem = re.sub(r"[^a-z0-9_]", "", stem)
@@ -107,10 +108,10 @@ def _normalise_stem(filename: str) -> str:
 
 def _match_metadata(filename: str) -> Optional[dict[str, str]]:
     stem = _normalise_stem(filename)
-    # Prefer exact prefix match on the longest key so e.g.
-    # "verordnung_ueber_die_technischen_..." wins over "verordnung".
+    # Substring match on the longest key first — handles the "Schweizerisches
+    # Obligationenrecht" case where the law-name root isn't at the start.
     for key in sorted(LAW_METADATA, key=len, reverse=True):
-        if stem.startswith(key):
+        if key in stem:
             return LAW_METADATA[key]
     return None
 

--- a/scripts/ingest/unis.py
+++ b/scripts/ingest/unis.py
@@ -91,18 +91,9 @@ SITES: dict[str, SiteConfig] = {
         keep_substrings=("/studium",),
         skip_substrings=("/news", "/medien", "/jobs", "/events", "/aktuell"),
     ),
-    "phzh": SiteConfig(
-        slug="phzh",
-        name="Pädagogische Hochschule Zürich",
-        url_prefix="https://phzh.ch/de/Ausbildung",
-        seeds=[
-            "https://phzh.ch/de/Ausbildung/",
-            "https://phzh.ch/de/Ausbildung/studiengaenge/",
-            "https://phzh.ch/de/Ausbildung/anmeldung-zulassung/",
-        ],
-        keep_substrings=("/ausbildung", "/Ausbildung"),
-        skip_substrings=("/news", "/aktuell", "/medien", "/jobs", "/events"),
-    ),
+    # phzh.ch is a SPA with no anchor links and no sitemap.xml — even
+    # rendered fetches return 0 internal navigable links. Dropped until
+    # we have a click-simulation crawler or a curated URL list.
 }
 
 
@@ -205,7 +196,7 @@ def run(site_arg: str, limit: int, dry_run: bool) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Ingest UZH/ETH/ZHAW/PHZH into Phase 1 .jsonl")
-    parser.add_argument("--site", choices=["uzh", "ethz", "zhaw", "phzh", "all"], default="all")
+    parser.add_argument("--site", choices=["uzh", "ethz", "zhaw", "all"], default="all")
     parser.add_argument("--limit", type=int, default=0,
                         help="Per-site URL cap (0 = default 150).")
     parser.add_argument("--dry-run", action="store_true")

--- a/scripts/ingest/zh_cantonal_law.py
+++ b/scripts/ingest/zh_cantonal_law.py
@@ -150,7 +150,15 @@ def _extract_pdf_text(pdf_path: Path) -> str:
         except Exception:
             continue
         text = re.sub(r"-\n(\w)", r"\1", text)
-        text = re.sub(r"(\S)\n(\S)", r"\1 \2", text)
+        # Collapse mid-sentence line breaks, but preserve newlines that
+        # precede a section marker (§ N / Art. N / Artikel N) — otherwise
+        # _SECTION_RE can't see them and adjacent statute sections get
+        # merged into a single oversized chunk.
+        text = re.sub(
+            r"(\S)\n(?!\s*(?:§|Art\.|Artikel)\s+\d)(\S)",
+            r"\1 \2",
+            text,
+        )
         text = re.sub(r"\n{3,}", "\n\n", text).strip()
         if text:
             parts.append(text)

--- a/scripts/ingest/zuerich_com.py
+++ b/scripts/ingest/zuerich_com.py
@@ -133,9 +133,14 @@ def run(limit: int, dry_run: bool) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     url_cats = _fetch_sitemap_urls()
+    # Put rarer categories first so a low --limit still reaches them.
+    # zuerich.com's sitemap is leisure-heavy and food_drink URLs sit
+    # ~position 1180+; limit=200 in the past truncated to 0 food_drink.
+    cat_priority = {"food_drink": 0, "leisure": 1}
+    url_cats.sort(key=lambda uc: cat_priority.get(uc[1], 9))
     if limit and limit < len(url_cats):
         url_cats = url_cats[:limit]
-        logger.info("Limited to first %d URLs.", limit)
+        logger.info("Limited to first %d URLs (rarer categories first).", limit)
 
     if dry_run:
         by_cat: dict[str, int] = {}


### PR DESCRIPTION
## Summary
Seven self-contained fixes uncovered while running the full Phase 1 ingest at scale.

- **chunker** — drop seeded overlap when it would prevent the next sentence from fitting; otherwise the loop emits and re-seeds the same chunk forever.
- **law_pdfs** — NFC-normalise filenames and substring-match metadata keys so all 8 federal-law PDFs match. 306 → 4,652 docs.
- **zh_cantonal_law** — preserve newlines before § markers when collapsing PDF line breaks. Docs 305 → 2,441 (--limit 100), oversized 188 → 36.
- **unis** — drop phzh (SPA, 0 anchor links).
- **emergency_refs** — add 7 sites (143, 147, Reden-kann-retten, Rega, USZ, Kispi, KaPo). 5 → 13 chunks.
- **food_drink_refs** — Gault Millau ZH-canton detail pages (147 docs).
- **zuerich_com / _base** — pull title before stripping nav/header (with og:title fallback) so 31 essen-trinken hubs ingest. Sort rarer categories first. food_drink 0 → 31 docs / 521 chunks.

After all fixes: **41,714 chunks** across 11 categories.

## Test plan
- [ ] Spot-check chunks/law/zh_cantonal_law/ — sections split per-§
- [ ] Spot-check chunks/food_drink/zuerich_com/ — 31 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)