### PR TITLE
deploy: consolidate ACME_EMAIL into repo-root .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ SRGSSR_CLIENT_SECRET=
 # (The previously-committed fallback key was rotated on 2026-04-21.)
 EVENTFROG_KEY=
 
-# Let's Encrypt contact email (Traefik ACME registration)
+# Let's Encrypt contact email — used by Caddy in the bunzli-app-edge container.
 ACME_EMAIL=sali@buenzli.space
 
 # Contact form → SMTP (Infomaniak mailbox auth)

--- a/deploy/pods/app/README.md
+++ b/deploy/pods/app/README.md
@@ -23,12 +23,14 @@ Network: `bunzli-app-net` (bridge, internal-only).
 
 ## Env
 
-Required env vars in `<repo>/.env`:
+All env vars live in **one place**: the repo-root `.env`. Both the
+`edge` and `api` services read it via `env_file: ../../../.env`.
+There is **no per-pod `.env`** for `bunzli-app` — keep it that way.
 
-- `ACME_EMAIL` — for Let's Encrypt
-- All variables consumed by `api_server.py` (see top-level `.env.example`)
+Required keys (see top-level `.env.example` for the full list):
 
-The compose file reads `<repo>/.env` directly (`env_file: ../../../.env`).
+- `ACME_EMAIL` — Let's Encrypt registration, used by Caddy.
+- `ANTHROPIC_API_KEY`, `LLM_*`, `SMTP_*`, `EVENTFROG_KEY` — consumed by the API.
 
 ## Deploy
 

--- a/deploy/pods/app/docker-compose.yml
+++ b/deploy/pods/app/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       - "./Caddyfile:/etc/caddy/Caddyfile:ro"
       - "./caddy/data:/data"
       - "./caddy/config:/config"
-    environment:
-      - ACME_EMAIL=${ACME_EMAIL}
+    env_file:
+      - ../../../.env
     restart: unless-stopped
     networks:
       - bunzli-app-net


### PR DESCRIPTION
## Summary

- Edge service now loads from the repo-root \`.env\` (same as api), via \`env_file: ../../../.env\`.
- Drops the separate \`deploy/pods/app/.env\` we accidentally needed during yesterday's restructure.
- Documents the single-\`.env\` policy in the pod README and clarifies the \`.env.example\` comment.

## Why

After the pod restructure, \`ACME_EMAIL\` lived in a small \`deploy/pods/app/.env\` — undocumented, separate from the main repo \`.env\`. Two secrets files per host is one too many.

## Deploy steps

\`\`\`bash
# 1. Make sure ACME_EMAIL is in the repo-root .env on the VPS
ssh bunzli@83.228.227.247 'grep -q ACME_EMAIL ~/zueribot/.env || echo "ACME_EMAIL=sali@buenzli.space" >> ~/zueribot/.env'

# 2. Pull, recreate edge
ssh bunzli@83.228.227.247 'cd ~/zueribot && git pull && cd deploy/pods/app && docker compose up -d --force-recreate edge'

# 3. Drop the now-orphan .env
ssh bunzli@83.228.227.247 'rm ~/zueribot/deploy/pods/app/.env'
\`\`\`

## Test plan

- [ ] \`curl https://buenzli.space/\` → 200
- [ ] \`curl https://buenzli.space/zuribot/health\` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)