### PR TITLE
docs(CLAUDE.md): correct chat path + flag structural debt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,9 @@ This file is read automatically by Claude at the start of every session in this 
 
 ## Project shape (one paragraph)
 
-Bünzli is a Zürich-focused AI assistant. The repo holds a FastAPI backend (`api_server.py`, `backend/`), a static landing site (`frontend/landing/`, Astro + Tailwind, two locales), a chat frontend (`frontend/chat/`), and a Docker Compose deployment (`deploy/`) targeting a single Infomaniak VPS in Zürich. Operational details (VPS IP, SSH user, env layout, smoke-test commands) live in `DEPLOY_NOTES.md` at the repo root — gitignored, present on Benedict's machine.
+Bünzli is a Zürich-focused AI assistant. The repo holds a FastAPI backend (`api_server.py`, `backend/`), a static landing site (`frontend/landing/`, Astro + Tailwind, two locales), the chat UI (currently *nested inside the landing app* at `frontend/landing/src/pages/chat/` with a React `BunzliChat` component under `frontend/landing/src/components/chat/`), and a Docker Compose deployment (`deploy/`) targeting a single Infomaniak VPS in Zürich. Operational details (VPS IP, SSH user, env layout, smoke-test commands) live in `DEPLOY_NOTES.md` at the repo root — gitignored, present on Benedict's machine.
+
+> **Structural debt — chat lives in the wrong place.** The chat is currently a route inside the landing Astro app, not its own frontend. It should be its own top-level folder (e.g. `frontend/chat/`), with its own build, its own Dockerfile, and its own Caddy route. As long as it lives inside the landing app, every chat change forces a full landing rebuild, the two products share a build pipeline that does not match their lifecycles, and prototype/demo work (e.g. `frontend/landing/public/prototype-pitch/`) sits awkwardly in the same tree. Flag this when scoping the next significant chat change — that is the right moment to extract.
 
 ---
 

--- a/frontend/landing/public/prototype-pitch/index.html
+++ b/frontend/landing/public/prototype-pitch/index.html
@@ -1,0 +1,478 @@
+<!doctype html>
+<html lang="de-CH">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>Bünzli — Prototyp</title>
+  <link rel="icon" href="/favicon.svg" />
+  <style>
+    :root {
+      --blue: #0070B4;
+      --blue-dark: #00407C;
+      --blue-light: #EDF5FA;
+      --orange: #F26522;
+      --green: #3D8A3E;
+      --navy: #08111F;
+      --bg: #FAF9F5;
+      --surface: #FFFFFF;
+      --user: #F2F3F5;
+      --border: #ECEAE3;
+      --text: #1A1A1A;
+      --muted: #6B7280;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; }
+    body {
+      font-family: 'Inter', -apple-system, system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      -webkit-font-smoothing: antialiased;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+    header {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 14px 20px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header .brand { display: flex; align-items: center; gap: 10px; }
+    header .logo {
+      width: 32px; height: 32px;
+      background: var(--blue);
+      color: white;
+      border-radius: 8px;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 700; font-size: 16px;
+    }
+    header .name { font-weight: 700; font-size: 17px; letter-spacing: -0.01em; }
+    header .tag {
+      font-size: 12px; color: var(--muted);
+      padding: 4px 8px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+    }
+    .trust-strip {
+      background: var(--blue-light);
+      border-bottom: 1px solid var(--border);
+      padding: 8px 20px;
+      display: flex;
+      gap: 18px;
+      flex-wrap: wrap;
+      justify-content: center;
+      font-size: 12px;
+      color: var(--blue-dark);
+    }
+    .trust-strip span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-weight: 500;
+    }
+    .trust-strip strong {
+      color: var(--navy);
+      font-weight: 700;
+    }
+    @media (max-width: 600px) {
+      .trust-strip { font-size: 11px; gap: 10px; padding: 8px 12px; }
+    }
+    main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      max-width: 760px;
+      width: 100%;
+      margin: 0 auto;
+      padding: 24px 20px 0;
+    }
+    .intro {
+      text-align: center;
+      padding: 32px 0 16px;
+    }
+    .intro h1 {
+      font-size: 28px;
+      margin: 0 0 8px;
+      letter-spacing: -0.02em;
+      font-weight: 700;
+    }
+    .intro p {
+      color: var(--muted);
+      margin: 0;
+      font-size: 15px;
+    }
+    .messages {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      padding: 16px 0;
+      overflow-y: auto;
+    }
+    .msg {
+      max-width: 88%;
+      padding: 12px 16px;
+      border-radius: 14px;
+      line-height: 1.5;
+      font-size: 15px;
+      white-space: pre-wrap;
+      animation: fadeIn 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    .msg.user {
+      background: var(--user);
+      align-self: flex-end;
+      border-bottom-right-radius: 4px;
+    }
+    .msg.bot {
+      background: var(--surface);
+      align-self: flex-start;
+      border: 1px solid var(--border);
+      border-bottom-left-radius: 4px;
+    }
+    .msg.bot .badge {
+      display: inline-block;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: white;
+      padding: 2px 8px;
+      border-radius: 999px;
+      margin-bottom: 8px;
+    }
+    .badge.action { background: var(--orange); }
+    .badge.info { background: var(--blue); }
+    .badge.local { background: var(--green); }
+    .actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 10px;
+      flex-wrap: wrap;
+    }
+    .actions button {
+      font-size: 13px;
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--blue);
+      background: white;
+      color: var(--blue);
+      cursor: pointer;
+      font-weight: 500;
+      font-family: inherit;
+      transition: all 0.15s;
+    }
+    .actions button:hover { background: var(--blue-light); }
+    .actions button.primary {
+      background: var(--blue);
+      color: white;
+    }
+    .actions button.primary:hover { background: var(--blue-dark); }
+    .suggestions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      padding: 12px 0 0;
+    }
+    .suggestions button {
+      font-size: 13px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      cursor: pointer;
+      font-family: inherit;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .suggestions button:hover {
+      border-color: var(--blue);
+      color: var(--blue);
+    }
+    .composer {
+      position: sticky;
+      bottom: 0;
+      background: var(--bg);
+      padding: 16px 0 20px;
+      display: flex;
+      gap: 10px;
+      align-items: flex-end;
+    }
+    .composer textarea {
+      flex: 1;
+      resize: none;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 12px 14px;
+      font-family: inherit;
+      font-size: 15px;
+      line-height: 1.4;
+      background: var(--surface);
+      outline: none;
+      max-height: 120px;
+    }
+    .composer textarea:focus { border-color: var(--blue); }
+    .composer button.send {
+      background: var(--blue);
+      color: white;
+      border: none;
+      border-radius: 14px;
+      padding: 0 18px;
+      height: 44px;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 15px;
+    }
+    .composer button.send:hover { background: var(--blue-dark); }
+    .composer button.send:disabled {
+      background: var(--border);
+      color: var(--muted);
+      cursor: not-allowed;
+    }
+    .typing {
+      display: inline-flex;
+      gap: 4px;
+      align-items: center;
+      padding: 6px 0;
+    }
+    .typing span {
+      width: 7px; height: 7px;
+      background: var(--muted);
+      border-radius: 50%;
+      animation: bounce 1.2s infinite;
+    }
+    .typing span:nth-child(2) { animation-delay: 0.15s; }
+    .typing span:nth-child(3) { animation-delay: 0.3s; }
+    @keyframes bounce {
+      0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+      30% { transform: translateY(-5px); opacity: 1; }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(6px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .footer-note {
+      text-align: center;
+      font-size: 11px;
+      color: var(--muted);
+      padding: 8px 20px 16px;
+      letter-spacing: 0.02em;
+    }
+    .footer-note strong { color: var(--text); }
+    @media (max-width: 600px) {
+      .intro h1 { font-size: 22px; }
+      .msg { max-width: 92%; font-size: 14px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="brand">
+      <div class="logo">B</div>
+      <div class="name">Bünzli</div>
+    </div>
+    <div class="tag">Prototyp · Demo</div>
+  </header>
+
+  <div class="trust-strip">
+    <span>🇨🇭 <strong>Schwiizer Hosting</strong> · Züri</span>
+    <span>🛡️ <strong>Sovereign</strong> · kei US-Cloud</span>
+    <span>🔒 Verschlüsselet</span>
+    <span>🚫 Kei Tracker</span>
+  </div>
+
+  <main>
+    <div class="intro" id="intro">
+      <h1>Grüezi! Ich bi de Bünzli.</h1>
+      <p>Dini Züri-AI — souverän, privat, in de Schwiiz dehei.</p>
+    </div>
+
+    <div class="messages" id="messages"></div>
+
+    <div class="suggestions" id="suggestions">
+      <button data-prompt="erz">🗑️ Wenn isch d'Ghüderabfuhr?</button>
+      <button data-prompt="zwn">🛣️ Schlagloch i de Limmatstrass mälde</button>
+      <button data-prompt="quandoo">🍽️ Tisch im Kronenhalle bueche</button>
+      <button data-prompt="weekend">🎉 Was lauft am Wuchenend?</button>
+      <button data-prompt="privacy">🔒 Wo sind mini Date?</button>
+    </div>
+
+    <div class="composer">
+      <textarea id="input" rows="1" placeholder="Frög de Bünzli öppis…"></textarea>
+      <button class="send" id="send">Sände</button>
+    </div>
+  </main>
+
+  <div class="footer-note">
+    <strong>Prototyp.</strong> Gschpräch sind script-basiert für d'Demo. Kei echti Backend-Verbindig.
+  </div>
+
+  <script>
+    const messagesEl = document.getElementById('messages');
+    const inputEl = document.getElementById('input');
+    const sendBtn = document.getElementById('send');
+    const suggestionsEl = document.getElementById('suggestions');
+    const introEl = document.getElementById('intro');
+
+    const scripts = {
+      erz: {
+        user: "Wenn isch d'Ghüderabfuhr bi mir?",
+        bot: {
+          badge: { type: 'local', text: 'ERZ · Hyper-local' },
+          text: "Bi dir z'Wipkinge, Rotbuechstrass:\n\n• **Donnstig 30. April** — Kartonsammlig\n• **Mäntig 4. Mai** — Bioabfall\n• **Mittwuch 6. Mai** — Hauskehricht\n\nSöll ich dir e Erinnerig is Calendar setze?",
+          actions: [
+            { label: 'Ja, Erinnerig setze', primary: true },
+            { label: 'Nei danke' }
+          ]
+        }
+      },
+      zwn: {
+        user: "Es Schlagloch i de Limmatstrass uf Höchi vom Lindenhof. Mälde mer das?",
+        bot: {
+          badge: { type: 'action', text: 'Züri wie neu · Aktion' },
+          text: "Klar. Ich ha s'für di vorbereitet:\n\n📍 **Limmatstrass 65, 8001 Züri**\n🛣️ Kategorii: *Strassenschade — Schlagloch*\n📷 Bild: chasch nochlade oder a'hänge\n\nIch schick das im Tiefbauamt im Name vo dir, sobald du «Mälde» druckst.",
+          actions: [
+            { label: 'Mälde', primary: true },
+            { label: 'Bild a\'hänge' },
+            { label: 'Abbreche' }
+          ]
+        }
+      },
+      quandoo: {
+        user: "Buech mer es Tisch i de Kronenhalle hüt am achti für zwöi.",
+        bot: {
+          badge: { type: 'action', text: 'Quandoo · Buechig' },
+          text: "Hüt am 20:00 Uhr für 2 Persone i de **Kronenhalle, Rämistrass 4**:\n\n✅ Verfüegbar: 19:45, 20:00, 20:30\n👤 Uf Name: Benedict\n📞 Bestätigig per SMS\n\nSöll ich am 20:00 reserviere?",
+          actions: [
+            { label: '20:00 reserviere', primary: true },
+            { label: 'Anderi Ziit' }
+          ]
+        }
+      },
+      weekend: {
+        user: "Was lauft am Wuchenend i Züri?",
+        bot: {
+          badge: { type: 'info', text: 'Curated · Lokal' },
+          text: "Da isch was bi dir i de Nöchi (Kreis 6 + Innestadt) lauft:\n\n🎷 **Sa 26.4** — Jazz im Moods, 21:00 (no Tickets)\n🌳 **Sa+So** — Frühligsmärt im Bürkliplatz\n🥾 **So 27.4** — Üetlibärg Wanderig, abe vom Triemli\n🎨 **So 27.4** — Kunsthuus: gratis Iitritt am ersta Sunntig\n\nWottsch zu eim Ticket oder Detail?"
+        }
+      },
+      privacy: {
+        user: "Wo werded mini Date gspicheret und wer cha si gseh?",
+        bot: {
+          badge: { type: 'local', text: 'Souveränität · Privatsphär' },
+          text: "Chläri Sach:\n\n🇨🇭 **Server in Züri** (Infomaniak) — kei Date verlönd d'Schwiiz.\n🛡️ **Kei US-Cloud, kei US-Provider** — du fallsch nöd unter de US CLOUD Act.\n🔒 **End-to-end verschlüsselet** zwüschet dim Browser und üs.\n👁️ **Nume du gsehsch dini Date** — mir verchaufed nüt, mir trainiered keini Modell mit dine Gschpräch.\n📂 **Du chasch jederziit alles abelade oder lösche** — DSG-konform.\n\nWottsch dini Date jetzt aaluege oder löschen?",
+          actions: [
+            { label: 'Mini Date aaluege', primary: true },
+            { label: 'Alles lösche' }
+          ]
+        }
+      }
+    };
+
+    function addMessage(role, content, opts = {}) {
+      const div = document.createElement('div');
+      div.className = `msg ${role}`;
+      if (role === 'bot' && opts.badge) {
+        const b = document.createElement('div');
+        b.className = `badge ${opts.badge.type}`;
+        b.textContent = opts.badge.text;
+        div.appendChild(b);
+      }
+      const p = document.createElement('div');
+      p.innerHTML = formatText(content);
+      div.appendChild(p);
+      if (opts.actions) {
+        const a = document.createElement('div');
+        a.className = 'actions';
+        opts.actions.forEach(act => {
+          const btn = document.createElement('button');
+          btn.textContent = act.label;
+          if (act.primary) btn.className = 'primary';
+          btn.onclick = () => handleAction(act.label);
+          a.appendChild(btn);
+        });
+        div.appendChild(a);
+      }
+      messagesEl.appendChild(div);
+      div.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+
+    function formatText(t) {
+      return t
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*(.+?)\*/g, '<em>$1</em>')
+        .replace(/\n/g, '<br>');
+    }
+
+    function showTyping() {
+      const div = document.createElement('div');
+      div.className = 'msg bot';
+      div.id = 'typing';
+      div.innerHTML = '<div class="typing"><span></span><span></span><span></span></div>';
+      messagesEl.appendChild(div);
+      div.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+
+    function hideTyping() {
+      const t = document.getElementById('typing');
+      if (t) t.remove();
+    }
+
+    function runScript(key) {
+      introEl.style.display = 'none';
+      const s = scripts[key];
+      if (!s) return;
+      addMessage('user', s.user);
+      showTyping();
+      setTimeout(() => {
+        hideTyping();
+        addMessage('bot', s.bot.text, { badge: s.bot.badge, actions: s.bot.actions });
+      }, 900);
+    }
+
+    function handleAction(label) {
+      addMessage('user', label);
+      showTyping();
+      setTimeout(() => {
+        hideTyping();
+        const replies = {
+          'Ja, Erinnerig setze': { text: "✅ Erinnerig gsetzt für **Mittwuch 5. Mai am 19:00** — am Aabig vor de Hauskehricht.", badge: { type: 'local', text: 'Erledigt' } },
+          'Mälde': { text: "✅ Mäldig isch raus.\n\n📨 Bestätigigsnummer: **ZWN-2026-04832**\nD'Stadt antwortet typischerwiis innert 5 Werktag direkt im Mail.", badge: { type: 'action', text: 'Züri wie neu · Bestätigt' } },
+          '20:00 reserviere': { text: "✅ Reservation bestätigt.\n\n🍽️ **Kronenhalle, Sa 26.4, 20:00 Uhr, 2 Pers.**\nSMS-Bestätigig isch underwegs uf dini Nummere.", badge: { type: 'action', text: 'Quandoo · Bestätigt' } }
+        };
+        const r = replies[label] || { text: "Verstande. Was suscht no?", badge: null };
+        addMessage('bot', r.text, { badge: r.badge });
+      }, 700);
+    }
+
+    suggestionsEl.querySelectorAll('button').forEach(btn => {
+      btn.onclick = () => runScript(btn.dataset.prompt);
+    });
+
+    sendBtn.onclick = () => {
+      const v = inputEl.value.trim();
+      if (!v) return;
+      introEl.style.display = 'none';
+      addMessage('user', v);
+      inputEl.value = '';
+      showTyping();
+      setTimeout(() => {
+        hideTyping();
+        addMessage('bot', "Das isch en Prototyp — versuech eini vo de Bispiel-Frage do obe (🗑️ 🛣️ 🍽️ 🎉) um z'gseh, was de Bünzli cha.", { badge: { type: 'info', text: 'Demo' } });
+      }, 600);
+    };
+
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendBtn.click();
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Correct outdated chat path in CLAUDE.md — it lives inside the landing app, not at \`frontend/chat/\`
- Flag the structure as debt: chat should be its own top-level folder with its own build and Caddy route

## Test plan
- [x] Path verified by inspection (\`frontend/landing/src/pages/chat/\` and \`frontend/landing/src/components/chat/\`)
- [ ] No-op for runtime, docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)