### PR TITLE
Paper community sections, doodle cards, Limmat waves

### DIFF
--- a/frontend/landing/src/components/sections/CompareAI.astro
+++ b/frontend/landing/src/components/sections/CompareAI.astro
@@ -1,5 +1,6 @@
 ---
 import SectionHeader from '../ui/SectionHeader.astro';
+import BinderHoles from '../ui/BinderHoles.astro';
 import type { TranslationSchema } from '../../i18n/translations/de';
 
 interface Props {
@@ -23,7 +24,7 @@ const columns = [
     answer: t.compareChatGPTAnswer,
     verdict: t.compareChatGPTVerdict,
     verdictColor: 'text-amber-700',
-    badge: { label: t.compareBadgeDanger, icon: '⚠️', class: 'text-amber-700 border-amber-500/40 bg-amber-50' },
+    badge: { label: t.compareBadgeDanger, icon: '⚠️', class: 'text-amber-700 !border-amber-500/70 bg-amber-50' },
   },
   {
     key: 'gemini',
@@ -34,7 +35,7 @@ const columns = [
     answer: t.compareGeminiAnswer,
     verdict: t.compareGeminiVerdict,
     verdictColor: 'text-amber-700',
-    badge: { label: t.compareBadgeDanger, icon: '⚠️', class: 'text-amber-700 border-amber-500/40 bg-amber-50' },
+    badge: { label: t.compareBadgeDanger, icon: '⚠️', class: 'text-amber-700 !border-amber-500/70 bg-amber-50' },
   },
   {
     key: 'bunzli',
@@ -46,13 +47,14 @@ const columns = [
     verdict: t.compareBunzliVerdict,
     verdictColor: 'text-tram-green',
     highlight: true,
-    badge: { label: t.compareBadgeSafe, icon: '✓', class: 'text-tram-green border-tram-green/40 bg-tram-green/5' },
+    badge: { label: t.compareBadgeSafe, icon: '✓', class: 'text-tram-green !border-tram-green/70 bg-tram-green/5' },
   },
 ];
 ---
 
-<section id="compare" class="py-20 sm:py-28 bg-zh-black-5">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6">
+<section id="compare" class="relative py-20 sm:py-28 bg-chat-bg">
+  <BinderHoles />
+  <div class="relative max-w-6xl mx-auto px-4 sm:px-6">
 
     <div class="mb-12" data-animate>
       <SectionHeader
@@ -85,10 +87,8 @@ const columns = [
     <div class="grid md:grid-cols-3 gap-4" data-animate>
       {columns.map((c) => (
         <div class:list={[
-          'rounded-md border p-5 flex flex-col',
-          c.highlight
-            ? 'bg-white border-zurich-blue/40 shadow-regular ring-1 ring-zurich-blue/10'
-            : 'bg-white border-zurich-border opacity-90',
+          'doodle-card p-5 flex flex-col bg-white',
+          c.highlight ? 'shadow-regular !border-zurich-blue/70' : 'opacity-90',
         ]}>
           <div class="flex items-center gap-2 mb-4">
             <div class:list={['w-8 h-8 rounded-full flex items-center justify-center', c.logoBg]}>
@@ -101,7 +101,7 @@ const columns = [
               />
             </div>
             <span class="text-sm font-semibold text-zurich-dark">{c.label}</span>
-            <span class:list={['ml-auto inline-flex items-center gap-1 text-[10px] font-mono font-semibold border rounded-full px-2 py-0.5', c.badge.class]}>
+            <span class:list={['doodle-pill ml-auto inline-flex items-center gap-1 text-[10px] font-mono font-semibold px-2 py-0.5', c.badge.class]}>
               <span aria-hidden="true">{c.badge.icon}</span>
               {c.badge.label}
             </span>

--- a/frontend/landing/src/components/sections/CompareAI.astro
+++ b/frontend/landing/src/components/sections/CompareAI.astro
@@ -57,6 +57,7 @@ const columns = [
     <div class="mb-12" data-animate>
       <SectionHeader
         eyebrow={t.compareEyebrow}
+        eyebrowTilt={1}
         heading={t.compareHeadline}
         subtext={t.compareSub}
       />

--- a/frontend/landing/src/components/sections/DayWithBunzli.astro
+++ b/frontend/landing/src/components/sections/DayWithBunzli.astro
@@ -22,6 +22,7 @@ const scenes = [
     <div class="mb-16" data-animate>
       <SectionHeader
         eyebrow={t.dayEyebrow}
+        eyebrowTilt={-2}
         heading=""
         subtext={t.daySub}
       >

--- a/frontend/landing/src/components/sections/Hero.astro
+++ b/frontend/landing/src/components/sections/Hero.astro
@@ -1,5 +1,6 @@
 ---
 import Button from '../ui/Button.astro';
+import Eyebrow from '../ui/Eyebrow.astro';
 import type { TranslationSchema } from '../../i18n/translations/de';
 import type { Locale } from '../../i18n/locales';
 
@@ -37,10 +38,9 @@ const prompts = [
 
       <!-- Left: copy -->
       <div class="min-w-0">
-        <div class="inline-flex items-center gap-2 border border-zurich-border rounded-full px-3 py-1 text-[11px] font-mono text-zurich-gray mb-6 bg-white">
-          <span class="w-1.5 h-1.5 rounded-full bg-tram-green animate-pulse"></span>
-          {t.heroEyebrow}
-        </div>
+        <p class="mb-6">
+          <Eyebrow tilt={-1}>{t.heroEyebrow}</Eyebrow>
+        </p>
 
         <h1 class="text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight leading-[1.05] sm:leading-[1.02] mb-6 text-zurich-dark break-words hyphens-auto" lang="de">
           {t.heroHeadline1}

--- a/frontend/landing/src/components/sections/Hero.astro
+++ b/frontend/landing/src/components/sections/Hero.astro
@@ -22,17 +22,6 @@ const prompts = [
 ---
 
 <section class="relative pt-24 pb-16 sm:pt-28 sm:pb-20 overflow-hidden bg-white">
-  <!-- Zürich-flag diagonal hatching — sparse, calm, Swiss -->
-  <svg class="absolute inset-0 w-full h-full opacity-[0.035] pointer-events-none" aria-hidden="true">
-    <defs>
-      <pattern id="zh-diag" width="120" height="120" patternUnits="userSpaceOnUse">
-        <!-- Only the diagonal, no cell border — cleaner, less nervous -->
-        <line x1="0" y1="120" x2="120" y2="0" stroke="#0070B4" stroke-width="1"/>
-      </pattern>
-    </defs>
-    <rect width="100%" height="100%" fill="url(#zh-diag)"/>
-  </svg>
-
   <div class="relative max-w-6xl mx-auto px-4 sm:px-6">
     <div class="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
 

--- a/frontend/landing/src/components/sections/JoinStrip.astro
+++ b/frontend/landing/src/components/sections/JoinStrip.astro
@@ -1,4 +1,5 @@
 ---
+import Eyebrow from '../ui/Eyebrow.astro';
 import type { TranslationSchema } from '../../i18n/translations/de';
 
 interface Props {
@@ -14,10 +15,9 @@ const launchTarget = '2026-06-01T00:00:00+02:00';
 <section id="join" class="py-20 sm:py-28 bg-zh-black-5 border-t border-zurich-border">
   <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
 
-    <div class="inline-flex items-center gap-2 border border-zurich-border rounded-full px-3 py-1 text-[11px] font-mono text-zurich-gray mb-6 bg-white" data-animate>
-      <span class="w-1.5 h-1.5 rounded-full bg-tram-green animate-pulse"></span>
-      {t.joinEyebrow}
-    </div>
+    <p class="mb-6" data-animate>
+      <Eyebrow tilt={-1}>{t.joinEyebrow}</Eyebrow>
+    </p>
 
     <h2 class="text-3xl sm:text-5xl font-extrabold tracking-tight text-zurich-dark mb-4" data-animate>
       {t.joinHeadline}

--- a/frontend/landing/src/components/sections/JoinStrip.astro
+++ b/frontend/landing/src/components/sections/JoinStrip.astro
@@ -1,5 +1,6 @@
 ---
 import Eyebrow from '../ui/Eyebrow.astro';
+import BinderHoles from '../ui/BinderHoles.astro';
 import type { TranslationSchema } from '../../i18n/translations/de';
 
 interface Props {
@@ -12,8 +13,14 @@ const { t } = Astro.props;
 const launchTarget = '2026-06-01T00:00:00+02:00';
 ---
 
-<section id="join" class="py-20 sm:py-28 bg-zh-black-5 border-t border-zurich-border">
-  <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+<section
+  id="join"
+  class="relative py-20 sm:py-28 bg-chat-bg"
+>
+
+  <BinderHoles />
+
+  <div class="relative max-w-3xl mx-auto px-4 sm:px-6 text-center">
 
     <p class="mb-6" data-animate>
       <Eyebrow tilt={-1}>{t.joinEyebrow}</Eyebrow>
@@ -48,19 +55,19 @@ const launchTarget = '2026-06-01T00:00:00+02:00';
         data-countdown
         data-target={launchTarget}
       >
-        <div class="flex flex-col items-center bg-white border border-zurich-border rounded-md px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
+        <div class="doodle-card flex flex-col items-center bg-white px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
           <span class="text-2xl sm:text-3xl font-bold text-zurich-dark font-mono tabular-nums" data-days>--</span>
           <span class="text-[10px] font-mono text-zurich-gray/70 uppercase tracking-wider mt-0.5">{t.joinCountdownDays}</span>
         </div>
-        <div class="flex flex-col items-center bg-white border border-zurich-border rounded-md px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
+        <div class="doodle-card flex flex-col items-center bg-white px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
           <span class="text-2xl sm:text-3xl font-bold text-zurich-dark font-mono tabular-nums" data-hours>--</span>
           <span class="text-[10px] font-mono text-zurich-gray/70 uppercase tracking-wider mt-0.5">{t.joinCountdownHours}</span>
         </div>
-        <div class="flex flex-col items-center bg-white border border-zurich-border rounded-md px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
+        <div class="doodle-card flex flex-col items-center bg-white px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
           <span class="text-2xl sm:text-3xl font-bold text-zurich-dark font-mono tabular-nums" data-minutes>--</span>
           <span class="text-[10px] font-mono text-zurich-gray/70 uppercase tracking-wider mt-0.5">{t.joinCountdownMinutes}</span>
         </div>
-        <div class="flex flex-col items-center bg-white border border-zurich-border rounded-md px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
+        <div class="doodle-card flex flex-col items-center bg-white px-3 sm:px-4 py-2 min-w-[60px] sm:min-w-[72px]">
           <span class="text-2xl sm:text-3xl font-bold text-zurich-blue font-mono tabular-nums" data-seconds>--</span>
           <span class="text-[10px] font-mono text-zurich-gray/70 uppercase tracking-wider mt-0.5">{t.joinCountdownSeconds}</span>
         </div>

--- a/frontend/landing/src/components/sections/LiveStatusBoard.astro
+++ b/frontend/landing/src/components/sections/LiveStatusBoard.astro
@@ -87,6 +87,7 @@ const clientI18n = t.boardClient;
     <div class="mb-12" data-animate>
       <SectionHeader
         eyebrow={t.boardEyebrow}
+        eyebrowTilt={1}
         heading={t.boardHeadline}
         subtext={t.boardSub}
       />

--- a/frontend/landing/src/components/sections/LiveStatusBoard.astro
+++ b/frontend/landing/src/components/sections/LiveStatusBoard.astro
@@ -1,5 +1,12 @@
 ---
 import SectionHeader from '../ui/SectionHeader.astro';
+import BinderHoles from '../ui/BinderHoles.astro';
+import Eyebrow from '../ui/Eyebrow.astro';
+
+// Cycle through small tilts so a row of tape strips doesn't feel
+// stamped — tape never gets stuck on perfectly straight.
+const TAPE_TILTS = [-2, -1, 1, 2] as const;
+const tiltFor = (i: number) => TAPE_TILTS[i % TAPE_TILTS.length];
 import type { TranslationSchema } from '../../i18n/translations/de';
 
 interface Props {
@@ -81,8 +88,9 @@ const connectorsLabel = t.boardConnectorsLabel.replace('{count}', String(others.
 const clientI18n = t.boardClient;
 ---
 
-<section id="board" class="py-20 sm:py-28 bg-zh-black-5 relative overflow-hidden">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6">
+<section id="board" class="py-20 sm:py-28 bg-chat-bg relative overflow-hidden">
+  <BinderHoles />
+  <div class="relative max-w-6xl mx-auto px-4 sm:px-6">
 
     <div class="mb-12" data-animate>
       <SectionHeader
@@ -107,11 +115,11 @@ const clientI18n = t.boardClient;
         {realtimeCells.map((c) => (
           <div
             id={`cell-${c.key}`}
-            class="bg-white border border-zurich-border rounded-md hover:border-tram-green/40 transition-all duration-150 p-3.5 sm:p-4"
+            class="doodle-card bg-white p-3.5 sm:p-4"
           >
             <div class="flex items-center justify-between mb-2">
               <span class="text-xl" aria-hidden="true">{c.emoji}</span>
-              <span class="inline-flex items-center gap-1.5 text-[10px] font-mono text-tram-green border border-tram-green/50 px-2 py-0.5 rounded-full">
+              <span class="doodle-pill inline-flex items-center gap-1.5 text-[10px] font-mono text-tram-green !border-tram-green/70 px-2 py-0.5">
                 <span class="live-dot w-1.5 h-1.5 rounded-full bg-tram-green"></span>
                 {t.boardLiveLabel}
               </span>
@@ -141,11 +149,11 @@ const clientI18n = t.boardClient;
         {staticCells.map((c) => (
           <div
             id={`cell-${c.key}`}
-            class="bg-white border border-zurich-border rounded-md hover:border-zurich-blue/30 transition-all duration-150 p-3.5 sm:p-4"
+            class="doodle-card bg-white p-3.5 sm:p-4"
           >
             <div class="flex items-center justify-between mb-2">
               <span class="text-xl" aria-hidden="true">{c.emoji}</span>
-              <span class="inline-flex items-center gap-1.5 text-[10px] font-mono text-zurich-blue border border-zurich-blue/40 px-2 py-0.5 rounded-full">
+              <span class="doodle-pill inline-flex items-center gap-1.5 text-[10px] font-mono text-zurich-blue !border-zurich-blue/70 px-2 py-0.5">
                 {t.boardTodayBadge}
               </span>
             </div>
@@ -167,11 +175,9 @@ const clientI18n = t.boardClient;
         <p class="text-[10px] font-mono text-zurich-gray/40 uppercase tracking-wider mb-2">
           {connectorsLabel}
         </p>
-        <div class="flex flex-wrap gap-x-2 gap-y-1.5">
-          {others.map((name) => (
-            <span class="text-[11px] font-mono text-zurich-gray/50 bg-white border border-zurich-border/60 rounded-full px-2.5 py-0.5 whitespace-nowrap">
-              {name}
-            </span>
+        <div class="flex flex-wrap gap-x-3 gap-y-3">
+          {others.map((name, i) => (
+            <Eyebrow tilt={tiltFor(i)} theme="paper">{name}</Eyebrow>
           ))}
         </div>
       </div>
@@ -181,12 +187,9 @@ const clientI18n = t.boardClient;
           <p class="text-[10px] font-mono text-zurich-gray/40 uppercase tracking-wider mb-2">
             {t.boardAgentsLabel}
           </p>
-          <div class="flex flex-wrap gap-2">
-            {agentsInProgress.map((a) => (
-              <span class="inline-flex items-center gap-1.5 text-[11px] font-mono text-zurich-gray/60 bg-white border border-dashed border-zurich-border rounded-full px-2.5 py-0.5 whitespace-nowrap">
-                <span>{a.emoji}</span>
-                {a.label}
-              </span>
+          <div class="flex flex-wrap gap-x-3 gap-y-3">
+            {agentsInProgress.map((a, i) => (
+              <Eyebrow tilt={tiltFor(i + 1)} theme="paper">{a.emoji} {a.label}</Eyebrow>
             ))}
           </div>
         </div>

--- a/frontend/landing/src/components/sections/OpenSource.astro
+++ b/frontend/landing/src/components/sections/OpenSource.astro
@@ -26,6 +26,7 @@ const stackParts = (t.openStackList as string).split(' · ');
     <div class="mb-14" data-animate>
       <SectionHeader
         eyebrow={t.openEyebrow}
+        eyebrowTilt={2}
         heading={t.openHeadline}
         subtext={t.openSub}
       />

--- a/frontend/landing/src/components/sections/PrivacyArchitecture.astro
+++ b/frontend/landing/src/components/sections/PrivacyArchitecture.astro
@@ -1,4 +1,5 @@
 ---
+import Eyebrow from '../ui/Eyebrow.astro';
 import type { TranslationSchema } from '../../i18n/translations/de';
 
 interface Props {
@@ -34,9 +35,7 @@ const pillars = [
     <!-- Header -->
     <div class="mb-14 text-center max-w-3xl mx-auto" data-animate>
       <p class="mb-4">
-        <span class="inline-block bg-white px-2.5 py-1 font-mono text-xs tracking-widest uppercase text-tram-green -rotate-1">
-          {t.privEyebrow}
-        </span>
+        <Eyebrow tilt={-1} theme="dark">{t.privEyebrow}</Eyebrow>
       </p>
       <h2 class="text-3xl sm:text-4xl md:text-5xl font-extrabold tracking-tight mb-4 text-white">
         {t.privHeadline}

--- a/frontend/landing/src/components/sections/PrivacyArchitecture.astro
+++ b/frontend/landing/src/components/sections/PrivacyArchitecture.astro
@@ -22,7 +22,78 @@ const pillars = [
 ];
 ---
 
-<section id="privacy" class="relative py-20 sm:py-28 overflow-hidden bg-zurich-blue text-white">
+<section id="privacy" class="relative py-20 sm:py-28 bg-zurich-blue text-white">
+
+  <!-- Limmat water surface — top edge.
+       Smooth sinusoidal wave (consistent amplitude + wavelength) with
+       a paler secondary wave behind it for ripple depth. Reads as the
+       water's surface rather than torn paper. -->
+  <svg
+    class="absolute -top-7 sm:-top-10 left-0 w-full h-7 sm:h-10 text-zurich-blue pointer-events-none"
+    viewBox="0 0 1200 40"
+    preserveAspectRatio="none"
+    aria-hidden="true"
+  >
+    <!-- Back ripple: lighter blue, slightly shifted phase -->
+    <path
+      d="M 0 40 L 0 28
+         Q 60 14, 120 22  Q 180 30, 240 22
+         Q 300 14, 360 22  Q 420 30, 480 22
+         Q 540 14, 600 22  Q 660 30, 720 22
+         Q 780 14, 840 22  Q 900 30, 960 22
+         Q 1020 14, 1080 22 Q 1140 30, 1200 22
+         L 1200 40 Z"
+      fill="currentColor"
+      opacity="0.55"
+    />
+    <!-- Front wave: full saturation, primary water line -->
+    <path
+      d="M 0 40 L 0 22
+         Q 50 10, 100 18  Q 150 26, 200 18
+         Q 250 10, 300 18  Q 350 26, 400 18
+         Q 450 10, 500 18  Q 550 26, 600 18
+         Q 650 10, 700 18  Q 750 26, 800 18
+         Q 850 10, 900 18  Q 950 26, 1000 18
+         Q 1050 10, 1100 18 Q 1150 26, 1200 18
+         L 1200 40 Z"
+      fill="currentColor"
+    />
+  </svg>
+
+  <!-- Limmat water surface — bottom edge.
+       Same wave language as the top, phase-shifted so the two edges
+       don't mirror identically. -->
+  <svg
+    class="absolute -bottom-7 sm:-bottom-10 left-0 w-full h-7 sm:h-10 text-zurich-blue pointer-events-none"
+    viewBox="0 0 1200 40"
+    preserveAspectRatio="none"
+    aria-hidden="true"
+  >
+    <!-- Back ripple -->
+    <path
+      d="M 0 0 L 0 12
+         Q 60 26, 120 18  Q 180 10, 240 18
+         Q 300 26, 360 18  Q 420 10, 480 18
+         Q 540 26, 600 18  Q 660 10, 720 18
+         Q 780 26, 840 18  Q 900 10, 960 18
+         Q 1020 26, 1080 18 Q 1140 10, 1200 18
+         L 1200 0 Z"
+      fill="currentColor"
+      opacity="0.55"
+    />
+    <!-- Front wave -->
+    <path
+      d="M 0 0 L 0 18
+         Q 50 30, 100 22  Q 150 14, 200 22
+         Q 250 30, 300 22  Q 350 14, 400 22
+         Q 450 30, 500 22  Q 550 14, 600 22
+         Q 650 30, 700 22  Q 750 14, 800 22
+         Q 850 30, 900 22  Q 950 14, 1000 22
+         Q 1050 30, 1100 22 Q 1150 14, 1200 22
+         L 1200 0 Z"
+      fill="currentColor"
+    />
+  </svg>
 
   <!-- Subtle dot grid -->
   <div

--- a/frontend/landing/src/components/ui/BinderHoles.astro
+++ b/frontend/landing/src/components/ui/BinderHoles.astro
@@ -1,0 +1,22 @@
+---
+// Row of keyhole-shaped rip-outs along the top edge of a section.
+// Each "hole" is a thin white rectangle reaching from the section's
+// top border down to a round white circle, like the paper has been
+// ripped out of a spiral binder. Render at the top of any section
+// that should read as a sheet of paper.
+interface Props {
+  count?: number;
+}
+const { count = 10 } = Astro.props;
+---
+<div
+  class="absolute top-0 left-0 right-0 flex justify-between px-8 sm:px-12 pointer-events-none"
+  aria-hidden="true"
+>
+  {Array.from({ length: count }).map(() => (
+    <span class="flex flex-col items-center">
+      <span class="block w-2 sm:w-2.5 h-4 bg-white"></span>
+      <span class="block w-5 h-5 sm:w-6 sm:h-6 rounded-full bg-white -mt-1.5"></span>
+    </span>
+  ))}
+</div>

--- a/frontend/landing/src/components/ui/Eyebrow.astro
+++ b/frontend/landing/src/components/ui/Eyebrow.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+  /** Tilt in degrees. Keep small — between -2 and +2. */
+  tilt?: -2 | -1 | 1 | 2;
+  /** Background context. `dark` flips text/bg so the block stays a white marker on dark sections. */
+  theme?: 'light' | 'dark';
+  class?: string;
+}
+
+const { tilt = -1, theme = 'light', class: className } = Astro.props;
+
+const tiltClass: Record<number, string> = {
+  [-2]: '-rotate-2',
+  [-1]: '-rotate-1',
+  [1]: 'rotate-1',
+  [2]: 'rotate-2',
+};
+
+const colorClass = theme === 'dark' ? 'bg-white text-tram-green' : 'bg-zurich-dark text-white';
+---
+
+<span
+  class:list={[
+    'inline-block px-2.5 py-1 font-mono text-xs tracking-widest uppercase',
+    colorClass,
+    tiltClass[tilt],
+    className,
+  ]}
+>
+  <slot />
+</span>

--- a/frontend/landing/src/components/ui/Eyebrow.astro
+++ b/frontend/landing/src/components/ui/Eyebrow.astro
@@ -2,8 +2,11 @@
 interface Props {
   /** Tilt in degrees. Keep small — between -2 and +2. */
   tilt?: -2 | -1 | 1 | 2;
-  /** Background context. `dark` flips text/bg so the block stays a white marker on dark sections. */
-  theme?: 'light' | 'dark';
+  /** Background context.
+   *  - light: blue tape on light section
+   *  - dark : white tape on dark section
+   *  - paper: white tape with tiny gray border (drop-shadow) on cream paper sections */
+  theme?: 'light' | 'dark' | 'paper';
   class?: string;
 }
 
@@ -22,7 +25,11 @@ const tiltClass: Record<number, string> = {
 // the teeth keep the same visual size regardless of how long the
 // eyebrow text is.
 const tapeColor =
-  theme === 'dark' ? 'bg-white text-zurich-blue' : 'bg-zurich-blue text-white';
+  theme === 'dark' ? 'bg-white text-zurich-blue'
+  : theme === 'paper' ? 'bg-white text-zurich-gray'
+  : 'bg-zurich-blue text-white';
+
+const tapeOutline = '';
 
 const torn =
   '[clip-path:polygon(5px_0%,calc(100%-5px)_0%,100%_16.7%,calc(100%-5px)_33.3%,100%_50%,calc(100%-5px)_66.7%,100%_83.3%,calc(100%-5px)_100%,5px_100%,0_83.3%,5px_66.7%,0_50%,5px_33.3%,0_16.7%)]';
@@ -33,6 +40,7 @@ const torn =
     'inline-block px-3.5 py-1 font-mono text-xs tracking-widest uppercase',
     torn,
     tapeColor,
+    tapeOutline,
     tiltClass[tilt],
     className,
   ]}

--- a/frontend/landing/src/components/ui/Eyebrow.astro
+++ b/frontend/landing/src/components/ui/Eyebrow.astro
@@ -16,13 +16,23 @@ const tiltClass: Record<number, string> = {
   [2]: 'rotate-2',
 };
 
-const colorClass = theme === 'dark' ? 'bg-white text-tram-green' : 'bg-zurich-dark text-white';
+// Torn-tape look: three clean triangular teeth on each end, like a strip
+// of tape ripped off a roll. Top + bottom stay straight (tape is cut
+// clean along its length, ripped at the ends). Spike depth is in px so
+// the teeth keep the same visual size regardless of how long the
+// eyebrow text is.
+const tapeColor =
+  theme === 'dark' ? 'bg-white text-zurich-blue' : 'bg-zurich-blue text-white';
+
+const torn =
+  '[clip-path:polygon(5px_0%,calc(100%-5px)_0%,100%_16.7%,calc(100%-5px)_33.3%,100%_50%,calc(100%-5px)_66.7%,100%_83.3%,calc(100%-5px)_100%,5px_100%,0_83.3%,5px_66.7%,0_50%,5px_33.3%,0_16.7%)]';
 ---
 
 <span
   class:list={[
-    'inline-block px-2.5 py-1 font-mono text-xs tracking-widest uppercase',
-    colorClass,
+    'inline-block px-3.5 py-1 font-mono text-xs tracking-widest uppercase',
+    torn,
+    tapeColor,
     tiltClass[tilt],
     className,
   ]}

--- a/frontend/landing/src/components/ui/SectionHeader.astro
+++ b/frontend/landing/src/components/ui/SectionHeader.astro
@@ -1,6 +1,10 @@
 ---
+import Eyebrow from './Eyebrow.astro';
+
 interface Props {
   eyebrow?: string;
+  /** Tilt for the marker eyebrow. Keep ≤ 2°. */
+  eyebrowTilt?: -2 | -1 | 1 | 2;
   heading: string;
   subtext?: string;
   align?: 'left' | 'center';
@@ -10,6 +14,7 @@ interface Props {
 
 const {
   eyebrow,
+  eyebrowTilt = -1,
   heading,
   subtext,
   align = 'center',
@@ -18,15 +23,14 @@ const {
 } = Astro.props;
 
 const alignClass = align === 'center' ? 'text-center mx-auto' : 'text-left';
-const eyebrowColor = theme === 'dark' ? 'text-tram-green' : 'text-zurich-blue';
 const headingColor = theme === 'dark' ? 'text-white' : 'text-zurich-dark';
 const subtextColor = theme === 'dark' ? 'text-white/60' : 'text-zurich-gray';
 ---
 
 <div class:list={['max-w-3xl', alignClass, className]}>
   {eyebrow && (
-    <p class:list={['font-mono text-xs tracking-widest uppercase mb-4', eyebrowColor]}>
-      {eyebrow}
+    <p class="mb-4">
+      <Eyebrow tilt={eyebrowTilt} theme={theme}>{eyebrow}</Eyebrow>
     </p>
   )}
   <h2 class:list={['text-3xl sm:text-4xl md:text-5xl font-extrabold tracking-tight mb-4', headingColor]}>

--- a/frontend/landing/src/layouts/Base.astro
+++ b/frontend/landing/src/layouts/Base.astro
@@ -51,7 +51,7 @@ const navLinks = [
     <meta name="twitter:image" content="https://buenzli.space/og-image.png" />
   </head>
   <body>
-    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-zurich-blue text-white px-4 py-2 rounded z-50">
+<a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-zurich-blue text-white px-4 py-2 rounded z-50">
       {t.navSkip}
     </a>
 

--- a/frontend/landing/src/styles/global.css
+++ b/frontend/landing/src/styles/global.css
@@ -194,3 +194,39 @@
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
+
+/* ── Pencil-sketch border ─────────────────────────────────────────
+   Used inside community ("paper") sections. The hand-drawn look
+   comes from asymmetric ELLIPTICAL border-radius — each corner has
+   very different horizontal and vertical radii, alternating
+   tall/wide around the box. The result reads as a rectangle
+   sketched in pencil without needing SVG filters or wobble.
+   Credit: technique from joeybeninghove/NyWePZ on CodePen. */
+
+.doodle-card {
+  border: 1.5px solid var(--color-zurich-border);
+  border-top-left-radius:     255px 15px;
+  border-top-right-radius:    15px 200px;
+  border-bottom-left-radius:  15px 255px;
+  border-bottom-right-radius: 200px 15px;
+}
+
+.doodle-pill {
+  border: 1px solid var(--color-zurich-border);
+  /* Hand-drawn oval: percentages keep it ellipse-shaped at any size,
+     slightly off-symmetric so it reads as circled by hand. */
+  border-radius: 50% 48% 52% 49% / 52% 50% 48% 51%;
+}
+/* Slight tilt that varies by parent card so neighbouring pills don't
+   all tilt the same direction. */
+.doodle-card:nth-child(odd)  .doodle-pill { transform: rotate(-2deg); }
+.doodle-card:nth-child(even) .doodle-pill { transform: rotate(1.5deg); }
+.doodle-card:nth-child(3n)   .doodle-pill { transform: rotate(-1deg); }
+/* Pills outside cards (e.g. connector list) — tilt by their own
+   position in the row. */
+.doodle-pill:nth-of-type(odd):not(.doodle-card .doodle-pill) {
+  transform: rotate(-1.5deg);
+}
+.doodle-pill:nth-of-type(even):not(.doodle-card .doodle-pill) {
+  transform: rotate(1.2deg);
+}


### PR DESCRIPTION
## Summary
- Section palette concept: **white = tech**, **cream paper = community**, **blue = privacy** (Limmat).
- Board / Compare / Join sections become "paper" with binder-hole rip-outs across the top.
- Cards and pills inside paper sections get a hand-drawn pencil look (asymmetric elliptical border-radius).
- Privacy section gets smooth Limmat-style water-wave edges (front wave + paler back ripple) instead of torn-paper jagged edges.
- Hero loses its diagonal hatching — clean white tech-section.
- Connector / agent rows in LiveStatusBoard switch to torn-tape Eyebrow strips (new white "paper" theme), tilted in different directions.

5 commits, ordered: eyebrow tape (prior session) → eyebrow tilt → hero clean → Limmat waves → paper community sections.

## Test plan
- [x] Verified locally in dev preview (mobile + desktop widths) for board, compare, join, privacy, hero.
- [ ] Smoke-test prod after deploy: home loads, all 4 sections render, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)