### PR TITLE
deploy: add asksaul.ch vhost to edge Caddyfile

### DIFF
--- a/deploy/pods/app/Caddyfile
+++ b/deploy/pods/app/Caddyfile
@@ -2,6 +2,7 @@
     email {$ACME_EMAIL}
 }
 
+# ── Bünzli ───────────────────────────────────────────────────────────
 www.buenzli.space {
     redir https://buenzli.space{uri} permanent
 }
@@ -16,5 +17,26 @@ buenzli.space {
 
     handle {
         reverse_proxy landing:80
+    }
+}
+
+# ── Better Ask Saul ──────────────────────────────────────────────────
+# Asksaul application containers run on a separate compose stack and
+# join bunzli-app-net externally so this edge can route to them by
+# container name. See ~/asksaul/deploy/ on the VPS.
+www.asksaul.ch {
+    redir https://asksaul.ch{uri} permanent
+}
+
+asksaul.ch {
+    encode gzip
+
+    # Same-origin API — front-end fetches /api/* on the same host.
+    handle_path /api/* {
+        reverse_proxy asksaul-api:8000
+    }
+
+    handle {
+        reverse_proxy asksaul-frontend:3000
     }
 }


### PR DESCRIPTION
## Summary
- Adds asksaul.ch + www.asksaul.ch vhosts to the edge Caddyfile
- Routes asksaul.ch/api/* → asksaul-api:8000
- Routes asksaul.ch (everything else) → asksaul-frontend:3000

The asksaul application containers live on a separate compose stack at \`~/asksaul/deploy/\` on the VPS and join \`bunzli-app-net\` externally, so this edge can route to them by container name.

## Test plan
- [x] DNS A + AAAA records for asksaul.ch + www point to the VPS (verified: \`dig +short asksaul.ch A\`)
- [ ] After merge + git pull on VPS + Caddy reload, \`https://asksaul.ch\` should serve the Next.js frontend
- [ ] \`https://asksaul.ch/api/health\` should return 200 from the FastAPI backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)