### PR TITLE
deploy(asksaul): preserve /api prefix in Caddy

### DIFF
--- a/deploy/pods/app/Caddyfile
+++ b/deploy/pods/app/Caddyfile
@@ -32,7 +32,9 @@ asksaul.ch {
     encode gzip
 
     # Same-origin API — front-end fetches /api/* on the same host.
-    handle_path /api/* {
+    # Use `handle` (not `handle_path`) so the /api prefix is preserved
+    # and FastAPI's @app.get("/api/health") routes match correctly.
+    handle /api/* {
         reverse_proxy asksaul-api:8000
     }
 


### PR DESCRIPTION
Hotfix: `handle_path` was stripping /api/ before reverse_proxy; FastAPI routes are `/api/health` not `/health`. Switched to `handle` to preserve the prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)