### PR TITLE
DeepSource PR 1: security & bug-risk findings

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -272,4 +272,4 @@ async def contact(req: ContactRequest, request: Request):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # skipcq: BAN-B104  (intentional: container binds to 0.0.0.0; Caddy is the public surface)

--- a/backend/connectors/water/handler.py
+++ b/backend/connectors/water/handler.py
@@ -1,6 +1,6 @@
 """Water connector — lake temperatures + Badi status for Zürich."""
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 import requests
 

--- a/backend/kb/metadata.py
+++ b/backend/kb/metadata.py
@@ -30,7 +30,7 @@ _SUBCATEGORY_RE = re.compile(r"^[a-z_]+/[a-z0-9_]+$")
 def make_doc_id(source_url: str, language: str) -> str:
     """Stable 12-char doc id. Same URL+lang always hashes to the same id."""
     key = f"{source_url}|{language}|{SCHEMA_VERSION}"
-    return hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+    return hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
 
 
 def make_chunk_id(doc_id: str, chunk_index: int | str) -> str:

--- a/frontend/landing/src/components/chat/BunzliChat.tsx
+++ b/frontend/landing/src/components/chat/BunzliChat.tsx
@@ -336,6 +336,10 @@ function AuthedChat() {
 
   const runtime = useRemoteThreadListRuntime({
     adapter: localThreadListAdapter,
+    // assistant-ui's API requires the property be named `runtimeHook`; the arrow
+    // function IS used as a hook (called from inside useRemoteThreadListRuntime),
+    // so the rule violation is a false positive driven by the property name.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     runtimeHook: () => useBunzliThreadRuntime(() => prefsRef.current),
   });
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ uvicorn>=0.29.0
 sse-starlette>=2.0.0
 requests>=2.31.0
 beautifulsoup4>=4.12.0
+defusedxml>=0.7.0
 pandas>=2.0.0
 PyJWT[crypto]>=2.8.0
 httpx>=0.27.0

--- a/scripts/ingest/_base.py
+++ b/scripts/ingest/_base.py
@@ -171,7 +171,7 @@ def crawl(fetcher: Fetcher, cfg: CrawlConfig) -> list[FetchResult]:
             continue
 
         soup = BeautifulSoup(res.content, "html.parser")
-        for a in soup.find_all("a", href=True):
+        for a in soup.find_all("a", href=True):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
             href = a["href"]
             if href.startswith("/"):
                 href = f"https://{res.final_url.split('/')[2]}{href}"

--- a/scripts/ingest/food_drink_refs.py
+++ b/scripts/ingest/food_drink_refs.py
@@ -236,7 +236,7 @@ def _discover_harrysding(fetcher: Fetcher, max_pages: int) -> list[SiteEntry]:
             break
         soup = BeautifulSoup(rendered.content, "html.parser")
         new_here = 0
-        for h in soup.find_all(["h2", "h3"]):
+        for h in soup.find_all(["h2", "h3"]):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
             a = h.find("a", href=True)
             if not a:
                 continue

--- a/scripts/ingest/parlament.py
+++ b/scripts/ingest/parlament.py
@@ -111,7 +111,7 @@ def _normalise_html(html: bytes) -> bytes:
     # the RichHtmlField wrapper.
     content = None
     best_len = 0
-    for div in soup.find_all("div", id=True):
+    for div in soup.find_all("div", id=True):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
         if "PublishingPageContent" in div.get("id", ""):
             txt_len = len(div.get_text(" ", strip=True))
             if txt_len > best_len:

--- a/scripts/ingest/stadt_zuerich.py
+++ b/scripts/ingest/stadt_zuerich.py
@@ -168,7 +168,7 @@ def _normalise_stzh_html(html: bytes) -> bytes:
         title = soup.title.get_text(strip=True).removesuffix(" | Stadt Zürich").strip()
 
     # Strip the decorative "Navigation" h1 and anything else at h1.
-    for h1 in soup.find_all("h1"):
+    for h1 in soup.find_all("h1"):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
         h1.decompose()
     if title and soup.body:
         new_h1 = soup.new_tag("h1")
@@ -176,7 +176,7 @@ def _normalise_stzh_html(html: bytes) -> bytes:
         soup.body.insert(0, new_h1)
 
     # stzh-heading → hN
-    for el in soup.find_all("stzh-heading"):
+    for el in soup.find_all("stzh-heading"):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
         try:
             n = int(el.get("level", "2"))
         except (TypeError, ValueError):
@@ -187,7 +187,7 @@ def _normalise_stzh_html(html: bytes) -> bytes:
         el.replace_with(new)
 
     # stzh-accordion-item → h3 + body wrapper
-    for el in soup.find_all("stzh-accordion-item"):
+    for el in soup.find_all("stzh-accordion-item"):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
         heading = (el.get("heading") or el.get("label") or "").strip()
         body_text = el.get_text(" ", strip=True)
         if heading and body_text.startswith(heading):

--- a/scripts/ingest/wikipedia.py
+++ b/scripts/ingest/wikipedia.py
@@ -168,7 +168,7 @@ def _clean_wikipedia_html(html: str, title: str) -> bytes:
             el.decompose()
 
     # Strip everything from a "References"-class heading onwards.
-    for h in soup.find_all(["h1", "h2", "h3"]):
+    for h in soup.find_all(["h1", "h2", "h3"]):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
         label = h.get_text(" ", strip=True).lower().strip()
         if label in _STRIP_HEADINGS:
             # Remove this heading and all following siblings.

--- a/scripts/ingest/zh_cantonal_law.py
+++ b/scripts/ingest/zh_cantonal_law.py
@@ -110,7 +110,7 @@ def _fetch_pdf(pdf_url: str, cache_dir: Path) -> Optional[Path]:
     """
     import hashlib
     cache_dir.mkdir(parents=True, exist_ok=True)
-    key = hashlib.sha1(pdf_url.encode()).hexdigest()[:16]
+    key = hashlib.sha1(pdf_url.encode(), usedforsecurity=False).hexdigest()[:16]
     path = cache_dir / f"{key}.pdf"
     if path.exists() and path.stat().st_size > 1024:
         return path

--- a/scripts/ingest/zh_ch_canton.py
+++ b/scripts/ingest/zh_ch_canton.py
@@ -152,7 +152,7 @@ def _normalise_html(html: bytes) -> bytes:
     if not title and soup.title:
         title = soup.title.get_text(strip=True).removesuffix(" | Kanton Zürich").strip()
 
-    for h1 in soup.find_all("h1"):
+    for h1 in soup.find_all("h1"):  # skipcq: PYL-E1133  (bs4 ResultSet is iterable; pylint can't infer)
         h1.decompose()
     if title and soup.body:
         new_h1 = soup.new_tag("h1")


### PR DESCRIPTION
## Summary
First of three planned passes through DeepSource findings. This PR closes the **security** and **bug-risk** buckets — 14 of the 31 issue types reported.

| Finding | Action |
|---|---|
| BAN-B405 / BAN-B314 — `xml.etree` parsing | **Fixed**: switched to `defusedxml` in the water connector. |
| PTC-W1003 — sha1 ×2 (doc IDs, PDF cache key) | Annotated `usedforsecurity=False`. Output is byte-identical, so no KB invalidation. |
| BAN-B104 — uvicorn binding to 0.0.0.0 | Suppressed with reason. Intentional inside the API container; Caddy is the public surface. |
| PYL-E1133 ×8 — bs4 `find_all` "non-iterable" | Suppressed with reason. False positive: `ResultSet` is iterable but pylint can't infer it. |
| JS-0820 — `runtimeHook` violates rules-of-hooks | Suppressed with reason. assistant-ui's API requires the property be named `runtimeHook`; we can't rename it. |

## Test plan
- [x] Hit Stadt ZH bath API via `WaterConnector.get_badi_info("Mythenquai")` post-defusedxml swap → returns live data
- [x] `make_doc_id` digest output is byte-identical with `usedforsecurity=False` kwarg → KB chunk_ids stable
- [ ] DeepSource re-runs against this branch and shows the 14 occurrences resolved (verify after merge)

## Out of scope
- PR 2 (planned): easy cleanup — unused imports, args, redundant comprehensions.
- PR 3 (planned): logging hygiene — convert `logger.x(f"...")` → `logger.x("%s", arg)`.
- Won't fix: prototype-pitch JS globals (×63), `any` types in demo code (×16), cyclomatic-complexity flags (×21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)