### PR TITLE
DeepSource PR 2: easy cleanup

### DIFF
--- a/backend/connectors/air_quality/handler.py
+++ b/backend/connectors/air_quality/handler.py
@@ -46,7 +46,7 @@ class AirQualityConnector(BaseConnector):
             if not rows:
                 return self.err("No air quality data available")
 
-            dates = set(r.get("Datum", "")[:10] for r in rows)
+            dates = {r.get("Datum", "")[:10] for r in rows}
             latest_date = sorted(dates)[-1]
             latest_rows = [r for r in rows if r.get("Datum", "").startswith(latest_date)]
 

--- a/backend/connectors/voting/handler.py
+++ b/backend/connectors/voting/handler.py
@@ -50,7 +50,7 @@ class VotingConnector(BaseConnector):
                 filtered = [r for r in filtered if r.get("Nr_Wahlkreis_StZH", "").strip() == kreis_str]
 
             if not date_filter and not level and not kreis:
-                dates = sorted(set(r.get("Abstimmungs_Datum", "") for r in filtered), reverse=True)
+                dates = sorted({r.get("Abstimmungs_Datum", "") for r in filtered}, reverse=True)
                 if dates:
                     latest_date = dates[0]
                     filtered = [r for r in filtered if r.get("Abstimmungs_Datum", "") == latest_date]

--- a/backend/kb/chunker.py
+++ b/backend/kb/chunker.py
@@ -116,7 +116,6 @@ def _sentences(text: str) -> list[str]:
 
 def _pack_sentences(
     sentences: list[str],
-    target_min: int,
     target_max: int,
     overlap_ratio: float,
 ) -> list[str]:
@@ -198,7 +197,7 @@ def _heading_path(doc: Document, *extra: str) -> str:
 
 # ── Per-doc_type chunkers ──────────────────────────────────────────────────
 
-def _chunk_article(doc: Document, target_min: int, target_max: int) -> list[tuple[str, str, Optional[str]]]:
+def _chunk_article(doc: Document, target_max: int) -> list[tuple[str, str, Optional[str]]]:
     """Return (display_text, heading_path_suffix, parent_ref_key) triples.
 
     parent_ref_key is a key identifying which parent section the child
@@ -215,7 +214,7 @@ def _chunk_article(doc: Document, target_min: int, target_max: int) -> list[tupl
             parent_key = sec.heading or "body"
 
         sentences = _sentences(sec.text)
-        pieces = _pack_sentences(sentences, target_min, target_max, OVERLAP_RATIO)
+        pieces = _pack_sentences(sentences, target_max, OVERLAP_RATIO)
         for piece in pieces:
             results.append((piece, sec.heading, parent_key))
 
@@ -237,7 +236,7 @@ def _chunk_procedure(doc: Document) -> list[tuple[str, str, Optional[int]]]:
 
     # Flat procedure text above the whole-limit: fall back to article packing.
     pieces = _pack_sentences(
-        _sentences(whole), TARGET_MIN, TARGET_MAX, OVERLAP_RATIO,
+        _sentences(whole), TARGET_MAX, OVERLAP_RATIO,
     )
     return [(p, "", i) for i, p in enumerate(pieces)]
 
@@ -263,7 +262,7 @@ def _chunk_statute(doc: Document) -> list[tuple[str, str, Optional[str]]]:
 
 def _chunk_historical(doc: Document) -> list[tuple[str, str, Optional[str]]]:
     """Same as article but with smaller target range."""
-    return _chunk_article(doc, HISTORICAL_MIN, HISTORICAL_MAX)
+    return _chunk_article(doc, HISTORICAL_MAX)
 
 
 # ── Public entry point ────────────────────────────────────────────────────
@@ -296,7 +295,7 @@ def chunk_document(doc: Document) -> list[Chunk]:
     doc_id = make_doc_id(doc.source_url, doc.language)
 
     dispatch = {
-        "article": lambda: _chunk_article(doc, TARGET_MIN, TARGET_MAX),
+        "article": lambda: _chunk_article(doc, TARGET_MAX),
         "historical": lambda: _chunk_historical(doc),
         "procedure": lambda: _chunk_procedure(doc),
         "reference": lambda: _chunk_reference(doc),
@@ -359,7 +358,7 @@ def _build(
     chunk_index: int | str,
     parent_chunk_id: Optional[str],
     display_text: str,
-    section_heading: str,
+    _section_heading: str,
     heading_path: str,
     *,
     step_index: Optional[int] = None,

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -1,1 +1,3 @@
 from backend.tools.tools import TOOL_DEFINITIONS, dispatch_tool
+
+__all__ = ["TOOL_DEFINITIONS", "dispatch_tool"]

--- a/evals/propose_improvements.py
+++ b/evals/propose_improvements.py
@@ -14,7 +14,6 @@ import argparse
 import json
 import pathlib
 import re
-import sys
 
 from .ollama_client import chat
 

--- a/scripts/audit_kb_section14.py
+++ b/scripts/audit_kb_section14.py
@@ -108,13 +108,17 @@ def audit():
                     ci = int(ci_raw)
                 except (TypeError, ValueError):
                     ci = 0
-                if ci > 0 and c.get("doc_type") != "statute" and disp:
-                    if starts_mid_word(disp):
-                        fails[key]["8_starts_mid_word"] += 1
-                        if len(examples["8_starts_mid_word"]) < 10:
-                            examples["8_starts_mid_word"].append(
-                                (category, source, c.get("chunk_id"), disp[:80])
-                            )
+                if (
+                    ci > 0
+                    and c.get("doc_type") != "statute"
+                    and disp
+                    and starts_mid_word(disp)
+                ):
+                    fails[key]["8_starts_mid_word"] += 1
+                    if len(examples["8_starts_mid_word"]) < 10:
+                        examples["8_starts_mid_word"].append(
+                            (category, source, c.get("chunk_id"), disp[:80])
+                        )
 
                 # 9. display_text doesn't start with heading_path
                 if hp and disp.lstrip().startswith(hp):

--- a/scripts/cleanup_kb.py
+++ b/scripts/cleanup_kb.py
@@ -54,10 +54,7 @@ MV_ALLOWED_PATTERNS = [
 
 def is_non_german_url(url: str) -> bool:
     """Return True if the URL is a non-German language page."""
-    for pattern in NON_DE_URL_PATTERNS:
-        if re.search(pattern, url, re.IGNORECASE):
-            return True
-    return False
+    return any(re.search(p, url, re.IGNORECASE) for p in NON_DE_URL_PATTERNS)
 
 
 def is_unwanted_mv(url: str, source_name: str) -> bool:
@@ -137,7 +134,7 @@ def run_cleanup(dry_run: bool = False) -> None:
         if len(ids) < batch_size:
             break
 
-    logger.info(f"\nChunks to remove:")
+    logger.info("\nChunks to remove:")
     logger.info(f"  Non-German language duplicates: {non_de_count}")
     logger.info(f"  Unwanted Mieterverband cantons: {mv_count}")
     logger.info(f"  Total to delete: {len(to_delete)}")

--- a/scripts/ingest/admin_federal.py
+++ b/scripts/ingest/admin_federal.py
@@ -229,7 +229,8 @@ def _run_site(profile: SiteProfile, limit: int, dry_run: bool) -> dict:
         max_depth = profile.bfs_max_depth
         logger.info("[%s] BFS mode — %d seeds, max_depth=%d, max_pages=%d",
                     profile.slug, len(seeds), max_depth, max_pages)
-        link_filter = lambda u: _is_allowed_path_substring(u, profile)
+        def link_filter(u):
+            return _is_allowed_path_substring(u, profile)
     else:
         all_urls = _fetch_sitemap_urls(profile)
         logger.info("[%s] sitemap: %d URLs total.", profile.slug, len(all_urls))

--- a/scripts/ingest/admin_federal.py
+++ b/scripts/ingest/admin_federal.py
@@ -32,7 +32,7 @@ import argparse
 import logging
 import re
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 from urllib.parse import urlparse
 

--- a/scripts/ingest/emergency_refs.py
+++ b/scripts/ingest/emergency_refs.py
@@ -274,7 +274,7 @@ def _extract_text(html: bytes) -> tuple[str, str]:
     a clean blob that the chunker emits as one chunk. We do however
     drop boilerplate like nav/footer/scripts.
     """
-    title, sections, full = extract_title_and_sections(html)
+    title, _sections, full = extract_title_and_sections(html)
     if full and len(full) >= 200:
         return title, full
 

--- a/scripts/ingest/emergency_refs.py
+++ b/scripts/ingest/emergency_refs.py
@@ -285,8 +285,8 @@ def _extract_text(html: bytes) -> tuple[str, str]:
                 "noscript", "form", "iframe"):
         for tag in soup.select(sel):
             tag.decompose()
-    main = soup.select_one("main") or soup.body or soup
-    text = main.get_text("\n", strip=True) if main else ""
+    main_el = soup.select_one("main") or soup.body or soup
+    text = main_el.get_text("\n", strip=True) if main_el else ""
     if not title:
         h = soup.find("h1") or soup.find("title")
         if h:

--- a/scripts/ingest/food_drink_refs.py
+++ b/scripts/ingest/food_drink_refs.py
@@ -190,7 +190,6 @@ def _discover_gaultmillau_zurich(fetcher: Fetcher, max_pages: int) -> list[SiteE
 
         h1 = soup.find("h1")
         name = h1.get_text(" ", strip=True) if h1 else url.rsplit("/", 1)[-1]
-        slug = url.rsplit("/", 1)[-1]
         out.append(SiteEntry(
             url=url,
             entity_name=name,

--- a/scripts/ingest/food_drink_refs.py
+++ b/scripts/ingest/food_drink_refs.py
@@ -137,7 +137,6 @@ def _discover_gaultmillau_zurich(fetcher: Fetcher, max_pages: int) -> list[SiteE
     ``max_pages`` caps the number of detail-page candidates probed (0 = no cap).
     """
     import re
-    from urllib.parse import urljoin
 
     INDEX = "https://www.gaultmillau.ch/sitemap.xml"
     LOC_RE = re.compile(r"<loc>([^<]+)</loc>")

--- a/scripts/ingest/food_drink_refs.py
+++ b/scripts/ingest/food_drink_refs.py
@@ -175,8 +175,8 @@ def _discover_gaultmillau_zurich(fetcher: Fetcher, max_pages: int) -> list[SiteE
         for sel in ("script", "style", "nav", "header", "footer", "aside"):
             for tag in soup.select(sel):
                 tag.decompose()
-        main = soup.select_one("main") or soup.body or soup
-        text_head = main.get_text("\n", strip=True)[:1000] if main else ""
+        main_el = soup.select_one("main") or soup.body or soup
+        text_head = main_el.get_text("\n", strip=True)[:1000] if main_el else ""
 
         # PLZ filter — Zürich canton is 8000-8999. Extra-canton PLZs
         # starting with 8 (e.g. 8580 Amriswil TG) exist but are rare;
@@ -287,8 +287,8 @@ def _extract_text(html: bytes) -> tuple[str, str]:
                 "noscript", "form", "iframe"):
         for tag in soup.select(sel):
             tag.decompose()
-    main = soup.select_one("main") or soup.body or soup
-    text = main.get_text("\n", strip=True) if main else ""
+    main_el = soup.select_one("main") or soup.body or soup
+    text = main_el.get_text("\n", strip=True) if main_el else ""
     if not title:
         h = soup.find("h1") or soup.find("title")
         if h:

--- a/scripts/ingest/leisure_refs.py
+++ b/scripts/ingest/leisure_refs.py
@@ -262,8 +262,8 @@ def _extract_text(html: bytes) -> tuple[str, str]:
                 "noscript", "form", "iframe"):
         for tag in soup.select(sel):
             tag.decompose()
-    main = soup.select_one("main") or soup.body or soup
-    text = main.get_text("\n", strip=True) if main else ""
+    main_el = soup.select_one("main") or soup.body or soup
+    text = main_el.get_text("\n", strip=True) if main_el else ""
     if not title:
         h = soup.find("h1") or soup.find("title")
         if h:

--- a/scripts/ingest/parlament.py
+++ b/scripts/ingest/parlament.py
@@ -37,7 +37,6 @@ import sys
 from typing import Optional
 from urllib.parse import unquote, urlparse
 
-import requests
 from bs4 import BeautifulSoup
 
 from backend.kb.fetchers import Fetcher

--- a/scripts/ingest/quartiervereine.py
+++ b/scripts/ingest/quartiervereine.py
@@ -132,7 +132,7 @@ _SKIP = (
 )
 
 
-def _link_filter_for(site: SiteConfig):
+def _link_filter_for(_site: SiteConfig):
     def keep(url: str) -> bool:
         path = urlparse(url).path.lower()
         if any(s in path for s in _SKIP):
@@ -144,7 +144,7 @@ def _link_filter_for(site: SiteConfig):
 
 
 def _subcategory_for_site(site: SiteConfig):
-    def fn(url: str) -> Optional[str]:
+    def fn(_url: str) -> Optional[str]:
         return f"{CATEGORY}/{site.slug}"
     return fn
 

--- a/scripts/ingest/stadt_zuerich.py
+++ b/scripts/ingest/stadt_zuerich.py
@@ -40,7 +40,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import requests
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup
 
 from backend.kb.fetchers import Fetcher
 from scripts.ingest._base import CrawlConfig, crawl, make_and_write

--- a/scripts/ingest/swissvotes.py
+++ b/scripts/ingest/swissvotes.py
@@ -29,7 +29,7 @@ import re
 import sys
 from datetime import date
 from typing import Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 import requests
 from bs4 import BeautifulSoup

--- a/scripts/ingest/swissvotes.py
+++ b/scripts/ingest/swissvotes.py
@@ -93,7 +93,7 @@ def _fetch_index_urls(timeout: int = 30, max_pages: int = 60) -> list[str]:
     return out
 
 
-def _extract_vote(html: bytes, url: str) -> Optional[tuple[str, str]]:
+def _extract_vote(html: bytes, _url: str) -> Optional[tuple[str, str]]:
     """Return (title, summary_text) for a vote-detail page, or None to skip."""
     soup = BeautifulSoup(html, "html.parser")
     for sel in ("script", "style", "nav", "header", "footer", "aside",

--- a/scripts/ingest/wikipedia.py
+++ b/scripts/ingest/wikipedia.py
@@ -28,7 +28,6 @@ import logging
 import sys
 import time
 from datetime import date
-from pathlib import Path
 from typing import Optional
 from urllib.parse import quote
 

--- a/scripts/ingest/zh_ch_canton.py
+++ b/scripts/ingest/zh_ch_canton.py
@@ -211,7 +211,7 @@ def run(limit: int, dry_run: bool) -> int:
         return 0
 
     # Map from URL → category for routing after fetch.
-    cat_by_url = {u: c for u, c in url_cats}
+    cat_by_url = dict(url_cats)
 
     cfg = CrawlConfig(
         seeds=[u for u, _ in url_cats],

--- a/scripts/ingest/zuerich_com.py
+++ b/scripts/ingest/zuerich_com.py
@@ -150,7 +150,7 @@ def run(limit: int, dry_run: bool) -> int:
             logger.info("  %-12s %4d", cat, n)
         return 0
 
-    cat_by_url = {u: c for u, c in url_cats}
+    cat_by_url = dict(url_cats)
 
     cfg = CrawlConfig(
         seeds=[u for u, _ in url_cats],


### PR DESCRIPTION
## Summary
Second pass through DeepSource findings. This PR closes the **easy cleanup** bucket — 30 occurrences across 10 issue types, all mechanical.

| Finding | Action |
|---|---|
| PY-W2000 — unused imports ×9 | Removed (or `__all__` for the `backend.tools` re-export). |
| PYL-W0612 — unused vars ×2 | One removed, one renamed `_sections`. |
| PYL-W0613 — unused args ×5 | Renamed with leading underscore; chunker.target_min removed end-to-end since it was dead through the call chain. |
| PYL-W0621 — `main` shadowing ×4 | Renamed local `main` → `main_el`. |
| PTC-W0015 — set(generator) ×2 | Switched to set comprehension. |
| PYL-R1721 — `{k: v for ...}` ×2 | `dict(url_cats)`. |
| PTC-W0027 — f-string no expr ×1 | Dropped the `f`. |
| PTC-W0048 — collapsible if ×1 | Merged the inner condition with `and`. |
| PY-W0074 — for→`any` ×1 | Single-expression `any(...)`. |
| FLK-E731 — named lambda ×1 | Replaced with nested `def`. |

## Test plan
- [x] All touched modules import cleanly
- [x] Spot-checked `is_non_german_url` (any-refactor) against the existing pattern list — same true/false outputs
- [x] Verified ingest helpers compile + import (no signature drift broke anything)
- [ ] DeepSource re-runs on this branch and shows the 30 occurrences resolved

## Out of scope
- PR 3 (planned): logging hygiene — convert `logger.x(f"...")` → `logger.x("%s", arg)` (~23 occurrences).
- Won't fix: prototype-pitch JS globals (×63), `any` types (×16), cyclomatic complexity (×21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)