### PR TITLE
DeepSource PR 3: logging hygiene (f-string → %-format)

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -99,7 +99,7 @@ async def _stream_generator(langchain_messages: list, model: str, chat_id: str):
                 continue
             yield f"data: {json.dumps({'id': chat_id, 'object': 'chat.completion.chunk', 'created': created, 'model': model, 'choices': [{'index': 0, 'delta': {'content': token}, 'finish_reason': None}]})}\n\n"
     except Exception as e:
-        logger.error(f"Error during streaming: {e}", exc_info=True)
+        logger.error("Error during streaming: %s", e, exc_info=True)
 
     # Stop chunk
     yield f"data: {json.dumps({'id': chat_id, 'object': 'chat.completion.chunk', 'created': created, 'model': model, 'choices': [{'index': 0, 'delta': {}, 'finish_reason': 'stop'}]})}\n\n"
@@ -156,7 +156,7 @@ async def chat_completions(request: ChatRequest, user: dict = Depends(require_us
         )
 
     except Exception as e:
-        logger.error(f"Error in chat_completions: {e}", exc_info=True)
+        logger.error("Error in chat_completions: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -185,7 +185,7 @@ def grade_rag_results(state: AgentState) -> AgentState:
                     content="[GRADER: Retrieved documents are not relevant to the question. I will search the web for a better answer.]"
                 )]}
     except Exception as e:
-        logger.warning(f"Grader failed (non-blocking): {e}")
+        logger.warning("Grader failed (non-blocking): %s", e)
 
     return state  # Relevant — continue normally
 
@@ -200,7 +200,7 @@ def call_tools(state: AgentState) -> AgentState:
         name = tc["name"]
         arguments = tc.get("args", {})
         
-        logger.info(f"Tool call: {name}({json.dumps(arguments, ensure_ascii=False)})")
+        logger.info("Tool call: %s(%s)", name, json.dumps(arguments, ensure_ascii=False))
         
         result = dispatch_tool(name, arguments)
         

--- a/backend/connectors/city_stats/handler.py
+++ b/backend/connectors/city_stats/handler.py
@@ -30,7 +30,7 @@ class CityStatsConnector(BaseConnector):
             df["Datum"] = pd.to_datetime(df["Datum"], errors="coerce")
             return df
         except Exception as e:
-            logger.error(f"Failed to load ERZ data: {e}")
+            logger.error("Failed to load ERZ data: %s", e)
             return None
 
     def _fetch_ewz(self) -> pd.DataFrame | None:
@@ -45,7 +45,7 @@ class CityStatsConnector(BaseConnector):
             df["zeitpunkt"] = pd.to_datetime(df["zeitpunkt"], errors="coerce", utc=True)
             return df
         except Exception as e:
-            logger.error(f"Failed to load EWZ data: {e}")
+            logger.error("Failed to load EWZ data: %s", e)
             return None
 
     def get_recycling_stats(self) -> dict:

--- a/backend/connectors/crime/handler.py
+++ b/backend/connectors/crime/handler.py
@@ -34,7 +34,7 @@ class CrimeConnector(BaseConnector):
             df.columns = [c.strip() for c in df.columns]
             return df
         except Exception as e:
-            logger.error(f"Failed to load crime data: {e}")
+            logger.error("Failed to load crime data: %s", e)
             return None
 
     def get_crime_stats(self, stadtkreis: str = "", category: str = "") -> dict:

--- a/backend/connectors/knowledge/handler.py
+++ b/backend/connectors/knowledge/handler.py
@@ -122,7 +122,7 @@ class KnowledgeConnector(BaseConnector):
         except FileNotFoundError as e:
             return self.err(e)
         except Exception as e:
-            logger.error(f"Knowledge base search failed: {e}", exc_info=True)
+            logger.error("Knowledge base search failed: %s", e, exc_info=True)
             return self.err(f"Knowledge base error: {str(e)}")
 
     def search_law_knowledge_base(self, query: str, limit: int = 5) -> dict:
@@ -222,5 +222,5 @@ class KnowledgeConnector(BaseConnector):
         except FileNotFoundError as e:
             return self.err(e)
         except Exception as e:
-            logger.error(f"Law knowledge base search failed: {e}", exc_info=True)
+            logger.error("Law knowledge base search failed: %s", e, exc_info=True)
             return self.err(f"Law knowledge base error: {str(e)}")

--- a/backend/connectors/pedestrian/handler.py
+++ b/backend/connectors/pedestrian/handler.py
@@ -48,7 +48,7 @@ class PedestrianConnector(BaseConnector):
             return df[df["timestamp"] >= cutoff]
 
         except Exception as e:
-            logger.error(f"Failed to load pedestrian data: {e}")
+            logger.error("Failed to load pedestrian data: %s", e)
             return None
 
     def get_pedestrian_counts(self, hours: int = 6) -> dict:

--- a/backend/connectors/rent/handler.py
+++ b/backend/connectors/rent/handler.py
@@ -42,7 +42,7 @@ class RentConnector(BaseConnector):
             ]
             return df
         except Exception as e:
-            logger.error(f"Failed to load rent data: {e}")
+            logger.error("Failed to load rent data: %s", e)
             return None
 
     def get_rent_prices(self, quartier: str = "", rooms: str = "", gemeinnuetzig: bool = False) -> dict:

--- a/backend/connectors/water_quality/handler.py
+++ b/backend/connectors/water_quality/handler.py
@@ -47,7 +47,7 @@ class WaterQualityConnector(BaseConnector):
             df["Datum"] = pd.to_datetime(df["Datum"], errors="coerce")
             return df
         except Exception as e:
-            logger.warning(f"Failed to load water quality data for {year}: {e}")
+            logger.warning("Failed to load water quality data for %s: %s", year, e)
             return None
 
     def _load(self) -> tuple[pd.DataFrame | None, int | None]:

--- a/scripts/cleanup_kb.py
+++ b/scripts/cleanup_kb.py
@@ -89,11 +89,11 @@ def run_cleanup(dry_run: bool = False) -> None:
     try:
         collection = client.get_collection(COLLECTION_NAME)
     except Exception:
-        logger.error(f"Collection '{COLLECTION_NAME}' not found at {STORE_PATH}")
+        logger.error("Collection '%s' not found at %s", COLLECTION_NAME, STORE_PATH)
         return
 
     total = collection.count()
-    logger.info(f"Total chunks in store: {total}")
+    logger.info("Total chunks in store: %s", total)
 
     # Fetch all records (metadata + ids, no embeddings needed)
     batch_size = 5000
@@ -123,22 +123,22 @@ def run_cleanup(dry_run: bool = False) -> None:
             if is_non_german_url(url):
                 to_delete.append(chunk_id)
                 non_de_count += 1
-                logger.debug(f"  [non-DE] {url}")
+                logger.debug("  [non-DE] %s", url)
 
             elif is_unwanted_mv(url, source_name):
                 to_delete.append(chunk_id)
                 mv_count += 1
-                logger.debug(f"  [mv-canton] {url}")
+                logger.debug("  [mv-canton] %s", url)
 
         offset += batch_size
         if len(ids) < batch_size:
             break
 
     logger.info("\nChunks to remove:")
-    logger.info(f"  Non-German language duplicates: {non_de_count}")
-    logger.info(f"  Unwanted Mieterverband cantons: {mv_count}")
-    logger.info(f"  Total to delete: {len(to_delete)}")
-    logger.info(f"  Remaining after cleanup: {total - len(to_delete)}")
+    logger.info("  Non-German language duplicates: %s", non_de_count)
+    logger.info("  Unwanted Mieterverband cantons: %s", mv_count)
+    logger.info("  Total to delete: %s", len(to_delete))
+    logger.info("  Remaining after cleanup: %s", total - len(to_delete))
 
     if not to_delete:
         logger.info("Nothing to delete.")
@@ -153,10 +153,10 @@ def run_cleanup(dry_run: bool = False) -> None:
     for i in range(0, len(to_delete), delete_batch):
         batch = to_delete[i:i + delete_batch]
         collection.delete(ids=batch)
-        logger.info(f"  Deleted batch {i // delete_batch + 1} ({len(batch)} chunks)")
+        logger.info("  Deleted batch %s (%s chunks)", i // delete_batch + 1, len(batch))
 
     remaining = collection.count()
-    logger.info(f"\nCleanup complete. Chunks remaining: {remaining}")
+    logger.info("\nCleanup complete. Chunks remaining: %s", remaining)
 
 
 def main():


### PR DESCRIPTION
## Summary
Third pass through DeepSource findings. Closes the **logging** bucket — 22 occurrences of PYL-W1203 (formatted string passed to logging module).

Converted every \`logger.<level>(f\"...\")\` to lazy \`logger.<level>(\"...\", arg)\` form across api_server.py, backend/agent.py, scripts/cleanup_kb.py, and seven connector handlers. Lazy %-format means the formatting cost is paid only when the record actually emits, and structured-log backends can introspect template-vs-args.

All kwargs (\`exc_info=True\` in two places) are preserved.

## Test plan
- [x] All touched modules import cleanly
- [x] Spot-checked a sample of conversions for correct argument order and preserved kwargs
- [x] No remaining \`logger.<level>(f\"\` in scope (grep clean)
- [ ] DeepSource re-runs and shows the 22 occurrences resolved

## What's left after this
With PRs 1-3 done, the remaining DeepSource findings are deliberate **won't-fix**:
- JS-0067 globals ×63 — prototype-pitch demo page, not real product code
- JS-0323 \`any\` types ×16 — same demo
- PY-R1000 / JS-R1005 cyclomatic complexity ×21 — judgement calls, no product reason to refactor
- A handful of misc JS minors in landing-page Astro components

I'll mark those as ignored in the DeepSource dashboard so the issue list reflects reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)