### PR TITLE
types(chat): replace any with structural ContentPart/MessageLike

### DIFF
--- a/frontend/landing/src/components/chat/BunzliChat.tsx
+++ b/frontend/landing/src/components/chat/BunzliChat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   AssistantRuntimeProvider,
   ComposerPrimitive,
@@ -19,24 +19,26 @@ import { localThreadListAdapter } from "./threads";
 import { ThreadSidebar } from "./ThreadSidebar";
 import { AuthProvider, useAuth } from "../../auth/AuthProvider";
 import { setAuthTokenGetter } from "./authToken";
+import type { ContentPart } from "./messageTypes";
+import { isTextPart } from "./messageTypes";
 
 // ── helpers ─────────────────────────────────────────────────────────────
 
-function messageText(content: readonly any[] | any[] | undefined): string {
+function messageText(content: readonly ContentPart[] | ContentPart[] | undefined): string {
   return (content ?? [])
-    .map((c: any) => (c.type === "text" ? c.text : ""))
+    .map((c) => (isTextPart(c) ? c.text : ""))
     .join("");
 }
 
 // ── icons (lucide-style, 1.75 stroke, 16px default) ────────────────────
 
 const Icon = {
-  ArrowUp: (p: any) => (
+  ArrowUp: (p: React.SVGProps<SVGSVGElement>) => (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...p}>
       <path d="M12 19V5M5 12l7-7 7 7" />
     </svg>
   ),
-  Shield: (p: any) => (
+  Shield: (p: React.SVGProps<SVGSVGElement>) => (
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" {...p}>
       <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
       <path d="M9 12l2 2 4-4" />
@@ -107,7 +109,7 @@ function FollowUps() {
 
   const suggestions = useMemo(() => {
     if (!lastAssistant || isRunning) return [] as string[];
-    const txt = messageText((lastAssistant as any).content).toLowerCase();
+    const txt = messageText((lastAssistant as { content?: readonly ContentPart[] }).content).toLowerCase();
     const pool: Record<string, string[]> = {
       tram: ["Zeig mir ui de Charte", "Wie lang isch d'Fahrt?"],
       wetter: ["Und übermorn?", "Wie isch s'Wasser im See?"],

--- a/frontend/landing/src/components/chat/Markdown.tsx
+++ b/frontend/landing/src/components/chat/Markdown.tsx
@@ -18,7 +18,7 @@ export function Markdown({ children }: { children: string }) {
           ul: (props) => <ul {...props} className="list-disc pl-6 my-3 space-y-1.5 marker:text-zurich-gray" />,
           ol: (props) => <ol {...props} className="list-decimal pl-6 my-3 space-y-1.5 marker:text-zurich-gray" />,
           li: (props) => <li {...props} className="pl-1" />,
-          code: ({ className, children, ...rest }: any) => {
+          code: ({ className, children, ...rest }) => {
             const isBlock = String(className || "").includes("language-");
             if (isBlock) {
               return (

--- a/frontend/landing/src/components/chat/ThreadSidebar.tsx
+++ b/frontend/landing/src/components/chat/ThreadSidebar.tsx
@@ -238,12 +238,17 @@ function LocationItem({
 function UserBadge() {
   const { state, logout } = useAuth();
   if (state.status !== "authenticated") return null;
-  const profile: any = state.user.profile ?? {};
+  const profile = (state.user.profile ?? {}) as {
+    name?: string;
+    preferred_username?: string;
+    email?: string;
+    sub?: string;
+  };
   const name: string =
     profile.name ||
     profile.preferred_username ||
     profile.email ||
-    (profile.sub as string) ||
+    profile.sub ||
     "Benutzer";
   const email: string | undefined = profile.email;
   const initial = name.trim().charAt(0).toUpperCase();

--- a/frontend/landing/src/components/chat/adapter.ts
+++ b/frontend/landing/src/components/chat/adapter.ts
@@ -2,6 +2,8 @@ import type { ChatModelAdapter } from "@assistant-ui/react";
 import type { Prefs } from "./prefs";
 import { buildContextBlock } from "./prefs";
 import { getAccessToken } from "./authToken";
+import type { ContentPart, MessageLike } from "./messageTypes";
+import { isTextPart } from "./messageTypes";
 
 const ENDPOINT = import.meta.env.DEV
   ? "http://localhost/zuribot/v1/chat/completions"
@@ -9,11 +11,11 @@ const ENDPOINT = import.meta.env.DEV
 
 type OpenAIMsg = { role: string; content: string };
 
-function toOpenAI(messages: readonly any[]): OpenAIMsg[] {
-  return messages.map((m: any) => ({
+function toOpenAI(messages: readonly MessageLike[]): OpenAIMsg[] {
+  return messages.map((m) => ({
     role: m.role,
-    content: (m.content || [])
-      .map((c: any) => (c.type === "text" ? c.text : ""))
+    content: (m.content ?? [])
+      .map((c: ContentPart) => (isTextPart(c) ? c.text : ""))
       .join(""),
   }));
 }

--- a/frontend/landing/src/components/chat/history.ts
+++ b/frontend/landing/src/components/chat/history.ts
@@ -83,7 +83,7 @@ export function makeThreadHistory(threadId: string): ThreadHistoryAdapter {
 
     async append(item: ExportedMessageRepositoryItem): Promise<void> {
       try {
-        const id = (item.message as any).id as string;
+        const id = (item.message as { id: string }).id;
         const plain: PlainItem = {
           id,
           parentId: item.parentId,

--- a/frontend/landing/src/components/chat/messageTypes.ts
+++ b/frontend/landing/src/components/chat/messageTypes.ts
@@ -1,0 +1,19 @@
+// Loose structural types for assistant-ui message content.
+//
+// The SDK's own types (ThreadMessage, MessageContentPart) are precise but
+// drift between versions; we only need the shape we actually read.
+
+export type TextPart = { type: "text"; text: string };
+
+// Any other block (tool_use, image, etc.) — we keep it open so a chunk
+// from a future SDK release won't break the type.
+export type ContentPart = TextPart | { type: string; [k: string]: unknown };
+
+export type MessageLike = {
+  role: string;
+  content?: readonly ContentPart[] | ContentPart[];
+};
+
+export function isTextPart(p: ContentPart): p is TextPart {
+  return p.type === "text" && typeof (p as TextPart).text === "string";
+}

--- a/frontend/landing/src/components/chat/threads.ts
+++ b/frontend/landing/src/components/chat/threads.ts
@@ -10,6 +10,8 @@ import {
 } from "./db";
 import { deleteThreadMessages } from "./history";
 import { getAccessToken } from "./authToken";
+import type { ContentPart, MessageLike } from "./messageTypes";
+import { isTextPart } from "./messageTypes";
 
 // On-disk row: id in clear (IDB key), rest encrypted.
 type ThreadRow = {
@@ -68,11 +70,11 @@ function truncateTitle(text: string, max = 48): string {
   return (lastSpace > max * 0.6 ? sliced.slice(0, lastSpace) : sliced).trim() + "…";
 }
 
-function extractText(message: any): string {
-  const parts = message?.content ?? [];
+function extractText(message: MessageLike): string {
+  const parts = message.content ?? [];
   if (!Array.isArray(parts)) return "";
   return parts
-    .map((p: any) => (p?.type === "text" ? p.text : ""))
+    .map((p: ContentPart) => (isTextPart(p) ? p.text : ""))
     .join("")
     .trim();
 }
@@ -217,8 +219,8 @@ export const localThreadListAdapter: RemoteThreadListAdapter = {
   },
 
   async generateTitle(remoteId, messages) {
-    const firstUser = messages.find((m: any) => m.role === "user");
-    const firstAssistant = messages.find((m: any) => m.role === "assistant");
+    const firstUser = (messages as readonly MessageLike[]).find((m) => m.role === "user");
+    const firstAssistant = (messages as readonly MessageLike[]).find((m) => m.role === "assistant");
     const userText = firstUser ? extractText(firstUser) : "";
     const assistantText = firstAssistant ? extractText(firstAssistant) : "";
 


### PR DESCRIPTION
## Summary
Closes [#44](https://github.com/benedictvonhoffmann-zuri-droid/zueribot/issues/44) — DeepSource JS-0323, 16 occurrences of \`any\` in the production chat code.

Introduced a tiny \`messageTypes.ts\` with the structural shapes we actually read from assistant-ui messages (text-part, content-part, message-like, plus an \`isTextPart\` guard). Bound to the loose structural type rather than the SDK's precise types, because the SDK's own \`ThreadAssistantMessagePart\` family drifts between minor releases — the structural shape is more stable for our needs.

Replacements:

| File | Before | After |
|---|---|---|
| adapter.ts, threads.ts, BunzliChat.tsx | \`any\` on message/content params | \`MessageLike\` / \`ContentPart\` |
| BunzliChat.tsx icons | \`(p: any)\` | \`React.SVGProps<SVGSVGElement>\` |
| Markdown.tsx code component | \`({...}: any)\` | inferred from \`Components["code"]\` |
| history.ts | \`item.message as any\` | \`as { id: string }\` |
| ThreadSidebar.tsx | \`profile: any\` | narrow record literal |

## Test plan
- [x] \`npm run typecheck\` clean for the touched files (the only remaining error, in crypto.ts, also exists on main and is a TS-lib Uint8Array/ArrayBuffer mismatch unrelated to this PR)
- [x] \`npm run build\` succeeds — all 6 pages emit, BunzliChat bundle unchanged
- [ ] **Preview verification deferred**: port 4321 was held by another worktree's preview during this session. Type-only change, but worth eyeballing the chat once after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)