### PR TITLE
fix(chat): pin Ciphertext Uint8Array buffer to ArrayBuffer

### DIFF
--- a/frontend/landing/src/components/chat/crypto.ts
+++ b/frontend/landing/src/components/chat/crypto.ts
@@ -37,7 +37,12 @@ function getKey(): Promise<CryptoKey> {
   return keyPromise;
 }
 
-export type Ciphertext = { iv: Uint8Array; data: Uint8Array };
+// Pin the buffer-type generic to ArrayBuffer (not ArrayBufferLike) so these
+// values are accepted as BufferSource by SubtleCrypto on TS 5.7+.
+export type Ciphertext = {
+  iv: Uint8Array<ArrayBuffer>;
+  data: Uint8Array<ArrayBuffer>;
+};
 
 export async function encryptJson(value: unknown): Promise<Ciphertext> {
   const key = await getKey();


### PR DESCRIPTION
## Summary
- TS 5.7+ no longer auto-coerces `Uint8Array<ArrayBufferLike>` to `BufferSource`, breaking `crypto.subtle.decrypt` in chat's `crypto.ts`.
- Pin `Ciphertext.iv` and `Ciphertext.data` to `Uint8Array<ArrayBuffer>` — matches what we actually allocate (`getRandomValues(new Uint8Array(...))` and `new Uint8Array(arrayBuffer)`).
- Chat is not live yet; risk is low. Just keeping `npm run typecheck` clean ahead of next chat session.

## Test plan
- [x] `npm run typecheck --prefix frontend/landing` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)