### PR TITLE
config: pin DeepSource analyzers + document scanner workflow

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,45 @@
+version = 1
+
+# Pin the analyzer surface explicitly so the dashboard reflects real product
+# code. Keep this list narrow on purpose — every entry here is something we
+# don't want graded.
+exclude_patterns = [
+  "venv/**",
+  "node_modules/**",
+  "**/node_modules/**",
+  "frontend/landing/dist/**",
+  "frontend/landing/.astro/**",
+  ".claude/**",
+  # Productschool pitch demo. Self-contained static page, not real product
+  # code; otherwise it dominates the dashboard with globals + any-types.
+  "frontend/landing/public/prototype-pitch/**",
+]
+
+test_patterns = [
+  "tests/**",
+  "**/test_*.py",
+  "**/*_test.py",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+]
+
+[[analyzers]]
+name = "python"
+
+  [analyzers.meta]
+  # Production runtime — see Dockerfile (python:3.11-slim).
+  runtime_version = "3.x.x"
+
+[[analyzers]]
+name = "javascript"
+
+  [analyzers.meta]
+  plugins = ["react"]
+  environment = ["browser", "nodejs"]
+  dialect = "typescript"
+
+[[analyzers]]
+name = "secrets"
+
+[[analyzers]]
+name = "docker"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,25 @@ Every session that deploys ends with a short business-focused summary Benedict c
 
 ---
 
+## DeepSource (code-quality scanner)
+
+Account: `benedictvonhoffmann-zuri-droid/zueribot` on DeepSource. The repo is graded on every push to `main`. Configuration lives in `.deepsource.toml` at the repo root — analyzer list, excludes (the prototype-pitch demo is excluded so it doesn't drown the dashboard), Python/JS metadata. Update that file when the analyzer surface changes, not the dashboard.
+
+To query findings programmatically (avoids manually copy-pasting from the web UI):
+
+```bash
+DS_KEY=$(grep '^DS_KEY=' /Users/benedictvonhoffmann/zuribot/.env | cut -d= -f2-)
+# GraphQL endpoint is api.deepsource.com (not .io). Auth scheme is Bearer.
+curl -sS -X POST https://api.deepsource.com/graphql/ \
+  -H "Authorization: Bearer $DS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ repository(name:\"zueribot\", login:\"benedictvonhoffmann-zuri-droid\", vcsProvider:GITHUB) { issues(first:50) { totalCount edges { node { issue { shortcode title category severity } occurrences(first:30) { edges { node { path beginLine title } } } } } } } }"}'
+```
+
+Workflow when working through findings: triage by severity + bug-risk first, then mechanical cleanup (unused imports, comprehensions), then logging hygiene. Suppress false positives inline with `# skipcq: <SHORTCODE>` (Python) or `// skipcq: <SHORTCODE>` (JS) and a one-line reason — the suppression is self-documenting at the call site rather than buried in the dashboard.
+
+---
+
 ## Memory system
 
 Benedict's per-project memory lives at `~/.claude/projects/-Users-benedictvonhoffmann-zuribot/memory/`. The `MEMORY.md` index is loaded into every session automatically. Use it for:


### PR DESCRIPTION
## Summary

Two small process improvements as a follow-up to the DeepSource cleanup pass.

**.deepsource.toml** — pins the analyzer list (python, javascript w/ react+typescript, secrets, docker) and excludes paths that shouldn't be graded:
- \`frontend/landing/public/prototype-pitch/**\` — the Productschool pitch demo. Without this exclude, ~80 findings inside the demo page dominated the dashboard.
- \`venv/**\`, \`node_modules/**\`, build outputs — standard noise.

**CLAUDE.md addendum** — short "DeepSource" section covering:
- Where config lives now
- The GraphQL endpoint quirk (\`api.deepsource.com\`, not \`.io\`) and auth scheme
- A canonical curl for fetching findings programmatically
- The inline-suppression convention (\`# skipcq: <CODE>\` + one-line reason)

## Test plan

- [x] TOML is valid (parsed locally)
- [ ] Next DeepSource scan respects the excludes — issue count for prototype-pitch drops from ~80 to 0

## What this is *not*

- No code changes. No \`review.md\` — discussed and decided not worth it: Claude Code already has a \`/review\` skill, and a static checklist has no clear reader in this single-PM setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)