### PR TITLE
ci: add dependabot.yml — docker + actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  # Container base images — opens a PR when python:3.11-slim, node:22-alpine,
+  # caddy:2, nginx:alpine, etc. publish a newer tag. Most base-image CVEs
+  # are fixed in the next image release, so weekly bump PRs cover most of
+  # the gap without needing a separate scanner.
+  #
+  # Watches Dockerfile* under each `directory`, plus any `image:` literals
+  # in docker-compose.yml in the same directory. Zitadel's compose at
+  # deploy/pods/app-iam/ uses ${VAR} interpolation for image tags, so
+  # Dependabot can't resolve them — pinned versions live in that pod's
+  # .env and need manual tracking.
+  - package-ecosystem: docker
+    directories:
+      - "/"                       # root Dockerfile (FastAPI / Python)
+      - "/deploy/pods/app"        # Dockerfile.landing + caddy:2 in compose
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(docker)"
+
+  # GitHub Actions used by CodeQL etc. — actions also accumulate
+  # vulns and bumping them weekly is cheap insurance.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(actions)"


### PR DESCRIPTION
## Summary

Adds \`.github/dependabot.yml\` so Dependabot opens weekly version-bump PRs for our container base images and GitHub Actions.

| Watched | Why |
|---|---|
| \`/Dockerfile\` | FastAPI/Python image (\`python:3.11-slim\`) |
| \`/deploy/pods/app/\` | landing's \`Dockerfile.landing\` (\`node:22-alpine\` + \`nginx:alpine\`) and \`caddy:2\` from \`docker-compose.yml\` |
| \`.github/workflows/\` (implicit) | CodeQL workflow's actions |

Most base-image CVEs land as a new image tag from the vendor — weekly bump PRs are a low-effort substitute for a dedicated scanner like Trivy. Sufficient for our scale (1 VPS, no users yet).

## Out of scope
- **Zitadel pod** (\`deploy/pods/app-iam/docker-compose.yml\`) uses \`\${VAR}\` interpolation for image tags. Dependabot can't resolve those, so the pins in that pod's \`.env\` stay manual for now.
- **Trivy or Docker Scout** — deeper CVE-level scanning. Not adding yet; Dependabot + Infomaniak's emails for kernel-tier issues should be enough at our scale.

## Test plan
- [x] YAML parses (PyYAML \`safe_load\`)
- [ ] After merge: GitHub Settings → Code security shows the two ecosystems active under "Dependabot version updates"
- [ ] First PR (or "everything up-to-date" status) appears within 24h